### PR TITLE
Migrate Checkbox component

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"node": ">=10.9"
 	},
 	"scripts": {
-		"dev": "start-storybook -s public",
+		"start": "start-storybook -s public",
 		"build": "build-storybook -o .storybook/build -s public",
 		"test": "echo \"Error: no test specified\" && exit 1",
 		"eslint": "eslint --ext .js,.jsx --ignore-path .gitignore --ignore-pattern backstop_data . --ignore-pattern bundles.js"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"start": "start-storybook -s public",
 		"build": "build-storybook -o .storybook/build -s public",
-		"test": "echo \"Error: no test specified\" && exit 1",
+		"test": "npm run eslint",
 		"eslint": "eslint --ext .js,.jsx --ignore-path .gitignore --ignore-pattern backstop_data . --ignore-pattern bundles.js"
 	},
 	"author": "",

--- a/src/components/Checkbox/Checkbox.jsx
+++ b/src/components/Checkbox/Checkbox.jsx
@@ -11,6 +11,7 @@ const Checkbox = ( {
 	ariaLabelledBy,
 	checked,
 	children,
+	disabled,
 	handleChange,
 	id,
 	invalid,
@@ -25,6 +26,7 @@ const Checkbox = ( {
 			aria-labelledby={ariaLabelledBy}
 			checked={checked}
 			className={cx( 'input', size )}
+			disabled={disabled}
 			id={id}
 			onChange={handleChange}
 			required={required}
@@ -40,6 +42,7 @@ Checkbox.propTypes = {
 	ariaLabelledBy: PropTypes.string,
 	checked: PropTypes.bool,
 	children: PropTypes.node,
+	disabled: PropTypes.bool.isRequired,
 	handleChange: PropTypes.func.isRequired,
 	id: PropTypes.string,
 	invalid: PropTypes.bool,
@@ -48,6 +51,7 @@ Checkbox.propTypes = {
 };
 
 Checkbox.defaultProps = {
+	disabled: false,
 	invalid: false,
 	required: false,
 	size: 'small',

--- a/src/components/Checkbox/Checkbox.jsx
+++ b/src/components/Checkbox/Checkbox.jsx
@@ -30,7 +30,7 @@ const Checkbox = ( {
 			required={required}
 			type="checkbox"
 		/>
-		{children && <span className={cx( 'label', size )}>{children}</span>}
+		{children && <span className={cx( 'label' )}>{children}</span>}
 	</label>
 );
 

--- a/src/components/Checkbox/Checkbox.jsx
+++ b/src/components/Checkbox/Checkbox.jsx
@@ -12,20 +12,22 @@ const Checkbox = ( {
 	checked,
 	children,
 	handleChange,
-	hasError,
 	id,
+	invalid,
+	required,
 	size,
 } ) => (
-	<label className={cx( 'container', { hasError } )}>
+	<label className={cx( 'container' )}>
 		<input
 			aria-describedby={ariaDescribedBy}
-			aria-invalid={hasError}
+			aria-invalid={invalid}
 			aria-label={ariaLabel}
 			aria-labelledby={ariaLabelledBy}
 			checked={checked}
 			className={cx( 'input', size )}
 			id={id}
 			onChange={handleChange}
+			required={required}
 			type="checkbox"
 		/>
 		{children && <span className={cx( 'label', size )}>{children}</span>}
@@ -39,13 +41,16 @@ Checkbox.propTypes = {
 	checked: PropTypes.bool,
 	children: PropTypes.node,
 	handleChange: PropTypes.func.isRequired,
-	hasError: PropTypes.bool,
 	id: PropTypes.string,
-	size: PropTypes.oneOf( [ 'large' ] ),
+	invalid: PropTypes.bool,
+	required: PropTypes.bool.isRequired,
+	size: PropTypes.oneOf( [ 'small', 'large' ] ),
 };
 
 Checkbox.defaultProps = {
-	hasError: false,
+	invalid: false,
+	required: false,
+	size: 'small',
 };
 
 export default Checkbox;

--- a/src/components/Checkbox/Checkbox.jsx
+++ b/src/components/Checkbox/Checkbox.jsx
@@ -12,9 +12,9 @@ const Checkbox = ( {
 	checked,
 	children,
 	disabled,
-	handleChange,
 	id,
 	invalid,
+	onChange,
 	required,
 	size,
 } ) => (
@@ -28,7 +28,7 @@ const Checkbox = ( {
 			className={cx( 'input', size )}
 			disabled={disabled}
 			id={id}
-			onChange={handleChange}
+			onChange={onChange}
 			required={required}
 			type="checkbox"
 		/>
@@ -43,9 +43,9 @@ Checkbox.propTypes = {
 	checked: PropTypes.bool,
 	children: PropTypes.node,
 	disabled: PropTypes.bool.isRequired,
-	handleChange: PropTypes.func.isRequired,
 	id: PropTypes.string,
 	invalid: PropTypes.bool,
+	onChange: PropTypes.func.isRequired,
 	required: PropTypes.bool.isRequired,
 	size: PropTypes.oneOf( [ 'small', 'large' ] ),
 };

--- a/src/components/Checkbox/Checkbox.jsx
+++ b/src/components/Checkbox/Checkbox.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './Checkbox.scss';
+import classnames from 'classnames/bind';
+
+const cx = classnames.bind( styles );
+
+const Checkbox = ( {
+	ariaDescribedBy,
+	ariaLabel,
+	ariaLabelledBy,
+	checked,
+	children,
+	handleChange,
+	hasError,
+	id,
+	size,
+} ) => (
+	<label className={cx( 'container', { hasError } )}>
+		<input
+			aria-describedby={ariaDescribedBy}
+			aria-invalid={hasError}
+			aria-label={ariaLabel}
+			aria-labelledby={ariaLabelledBy}
+			checked={checked}
+			className={cx( 'input', size )}
+			id={id}
+			onChange={handleChange}
+			type="checkbox"
+		/>
+		{children && <span className={cx( 'label', size )}>{children}</span>}
+	</label>
+);
+
+Checkbox.propTypes = {
+	ariaDescribedBy: PropTypes.string,
+	ariaLabel: PropTypes.string,
+	ariaLabelledBy: PropTypes.string,
+	checked: PropTypes.bool,
+	children: PropTypes.node,
+	handleChange: PropTypes.func.isRequired,
+	hasError: PropTypes.bool,
+	id: PropTypes.string,
+	size: PropTypes.oneOf( [ 'large' ] ),
+};
+
+Checkbox.defaultProps = {
+	hasError: false,
+};
+
+export default Checkbox;

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -10,7 +10,7 @@
 	color: $color-typography;
 	cursor: pointer;
 	display: flex;
-	align-items: inherit;
+	align-items: center;
 
 	&:hover {
 		color: $color-accent;
@@ -30,8 +30,8 @@
 .input {
 	@include reset-checkbox;
 
-	height: 15px;
-	width: 15px;
+	height: 16px;
+	width: 16px;
 	margin-right: 12px;
 	border-radius: 2px;
 	border: $border-solid-interactive;
@@ -71,13 +71,6 @@
 
 .label {
 	color: $color-typography-faint;
-
-	/* Line height should match height of checkbox */
-	line-height: 15px;
+	line-height: 1;
 	width: 100%;
-
-	&.large {
-		line-height: 16px;
-		margin-top: 2px;
-	}
 }

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -66,7 +66,6 @@
 }
 
 .label {
-	color: $color-typography-faint;
 	line-height: 1;
 	width: 100%;
 }

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -21,12 +21,6 @@
 	}
 }
 
-.label,
-.input {
-	transition-duration: $time-slowly;
-	transition-property: background-color, border-color, color;
-}
-
 .input {
 	@include reset-checkbox;
 
@@ -39,6 +33,8 @@
 	flex-shrink: 0;
 	flex-grow: 0;
 	cursor: pointer;
+	transition-duration: $time-slowly;
+	transition-property: background-color, border-color;
 
 	&:checked {
 		background-repeat: no-repeat;

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -42,8 +42,8 @@
 
 	&:checked {
 		background-repeat: no-repeat;
-		background-position: 3px 3px;
-		background-size: 9px;
+		background-position: 50%;
+		background-size: 75%;
 		background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSIxMSIgdmlld0JveD0iMTgzIDE4IDEyIDExIj48cGF0aCBzdHlsZT0iZmlsbDp2YXIoLS1jb2xvciwgI2ZmZikiIGZpbGwtcnVsZT0iZXZlbm9kZCIgZD0iTTE5My4yOTQgMThsLTYuMzUgNi45NjgtMi4zMzUtMi40OEwxODMgMjQuMjAxbDMuODYgNC4xMTNMMTk1IDE5LjU4eiIvPjwvc3ZnPg==');
 		background-color: $color-accent;
 		border-color: $color-accent;
@@ -66,11 +66,6 @@
 	&.large {
 		height: 20px;
 		width: 20px;
-
-		&:checked {
-			background-position: 4px 4px;
-			background-size: 12px;
-		}
 	}
 }
 

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -44,7 +44,7 @@
 		background-repeat: no-repeat;
 		background-position: 3px 3px;
 		background-size: 9px;
-		background-image: url('/public/svg/check.svg?fill=fff');
+		background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMiIgaGVpZ2h0PSIxMSIgdmlld0JveD0iMTgzIDE4IDEyIDExIj48cGF0aCBzdHlsZT0iZmlsbDp2YXIoLS1jb2xvciwgI2ZmZikiIGZpbGwtcnVsZT0iZXZlbm9kZCIgZD0iTTE5My4yOTQgMThsLTYuMzUgNi45NjgtMi4zMzUtMi40OEwxODMgMjQuMjAxbDMuODYgNC4xMTNMMTk1IDE5LjU4eiIvPjwvc3ZnPg==');
 		background-color: $color-accent;
 		border-color: $color-accent;
 	}

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -54,6 +54,12 @@
 		}
 	}
 
+	&:disabled,
+	&:disabled:hover {
+		opacity: 0.5;
+		border: $border-solid-interactive;
+	}
+
 	&.large {
 		height: 20px;
 		width: 20px;

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -5,16 +5,11 @@
 @import '~@quartz/styles/scss/tokens';
 
 .container {
-	@include font-maison-500-1;
+	@include font-maison;
 
-	color: $color-typography;
 	cursor: pointer;
 	display: flex;
 	align-items: center;
-
-	&:hover {
-		color: $color-accent;
-	}
 
 	&.has-error {
 		color: $color-red;

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -1,0 +1,88 @@
+@import '~@quartz/styles/scss/borders';
+@import '~@quartz/styles/scss/color-scheme';
+@import '~@quartz/styles/scss/fonts';
+@import '~@quartz/styles/scss/helpers/resets';
+@import '~@quartz/styles/scss/tokens';
+
+.container {
+	@include font-maison-500-1;
+
+	color: $color-typography;
+	cursor: pointer;
+	display: flex;
+	align-items: inherit;
+
+	&:hover {
+		color: $color-accent;
+	}
+
+	&.has-error {
+		color: $color-red;
+	}
+}
+
+.label,
+.input {
+	transition-duration: $time-slowly;
+	transition-property: background-color, border-color, color;
+}
+
+.input {
+	@include reset-checkbox;
+
+	height: 15px;
+	width: 15px;
+	margin-right: 12px;
+	border-radius: 2px;
+	border: $border-solid-interactive;
+	background-color: $color-background-2;
+	flex-shrink: 0;
+	flex-grow: 0;
+	cursor: pointer;
+
+	&:checked {
+		background-repeat: no-repeat;
+		background-position: 3px 3px;
+		background-size: 9px;
+		background-image: url('/public/svg/check.svg?fill=fff');
+		background-color: $color-accent;
+		border-color: $color-accent;
+	}
+
+	&:focus,
+	&:hover {
+		color: $color-accent;
+		border-color: $color-accent;
+	}
+
+	&[aria-invalid=true] {
+		&,
+		&:checked,
+		&:hover {
+			border-color: $color-red;
+		}
+	}
+
+	&.large {
+		height: 20px;
+		width: 20px;
+
+		&:checked {
+			background-position: 4px 4px;
+			background-size: 12px;
+		}
+	}
+}
+
+.label {
+	color: $color-typography-faint;
+
+	/* Line height should match height of checkbox */
+	line-height: 15px;
+	width: 100%;
+
+	&.large {
+		line-height: 16px;
+		margin-top: 2px;
+	}
+}

--- a/src/components/Checkbox/Checkbox.stories.mdx
+++ b/src/components/Checkbox/Checkbox.stories.mdx
@@ -22,3 +22,10 @@ Large checkbox
   </Story>
 </Preview>
 
+Required, invalid checkbox
+
+<Preview>
+  <Story name="Invalid">
+    <Checkbox invalid={true} required={true}>I agree to the terms and conditions (required)</Checkbox>
+  </Story>
+</Preview>

--- a/src/components/Checkbox/Checkbox.stories.mdx
+++ b/src/components/Checkbox/Checkbox.stories.mdx
@@ -29,3 +29,11 @@ Required, invalid checkbox
     <Checkbox invalid={true} required={true}>I agree to the terms and conditions (required)</Checkbox>
   </Story>
 </Preview>
+
+Disabled checkbox
+
+<Preview>
+  <Story name="Disabled">
+    <Checkbox disabled={true}>Can’t check this</Checkbox>
+  </Story>
+</Preview>

--- a/src/components/Checkbox/Checkbox.stories.mdx
+++ b/src/components/Checkbox/Checkbox.stories.mdx
@@ -1,0 +1,24 @@
+import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import Checkbox from './Checkbox';
+
+<Meta title="Checkbox" component={Checkbox} />
+
+# Checkbox
+
+With `MDX` we can define a story for `Checkbox` right in the middle of our
+markdown documentation.
+
+<Preview>
+  <Story name="Default">
+    <Checkbox>Check me out!</Checkbox>
+  </Story>
+</Preview>
+
+Large checkbox
+
+<Preview>
+  <Story name="Large">
+    <Checkbox size="large">Woah, Nelly!</Checkbox>
+  </Story>
+</Preview>
+

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,4 @@
 export { default as Button, ButtonLink } from './Button/Button';
+export { default as Checkbox } from './Checkbox/Checkbox';
 export { default as Link } from './Link/Link';
 export { default as Spinner } from './Spinner/Spinner';


### PR DESCRIPTION
Migrates the Checkbox component from qz-react, with a few small changes:

- Improve prop names for ease-of-use: 
  - `text` becomes `children`
  - `label` becomes `ariaLabel`
  - `describedBy` becomes `ariaDescribedBy`
  - `labelledBy` becomes `ariaLabelledBy`
  - `hasError` becomes `invalid`
- Uses a base64 inlined version of the checkmark SVG, which is not available to us otherwise
- Cleans up some CSS
- Adds a `required` prop for controlling the HTML `required` attribute
- Increase small size checkbox to 16x16px (from 15x15)
