### PR TITLE
Image component

### DIFF
--- a/src/components/Image/Image.docs.mdx
+++ b/src/components/Image/Image.docs.mdx
@@ -3,7 +3,7 @@ import Image from './Image';
 
 # Image
 
-Displays an image. The `Image` component requires `height` and `width` to set aspect ratio and `sizes` and `srcSet` to provide [responsive rendering](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images). They will not be calculated for you and there are no default values. Future components may provide a simpler implementation for specific use cases.
+Displays an image. The `Image` component requires `fallbackHeight` and `fallbackWidth` to set aspect ratio and `sizes` and `srcSet` to provide [responsive rendering](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images). They will not be calculated for you and there are no default values. Future components may provide a simpler implementation for specific use cases.
 
 This component does not provide [art direction](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture), which is also a task for a future component.
 
@@ -20,10 +20,10 @@ import { Image } from '@quartz/interface/src/components';
 ## Usage guidelines
 
 - **Do** use a container to constrain the size or shape of the image. An `Image` will always expand or contract to fit the width of its container. The `Image` component purposefully does not accept a `className` prop.
-- **Do** understand that the `height` and `width` props are [used to help the browser reserve space](https://blog.logrocket.com/jank-free-page-loading-with-media-aspect-ratios/) for the image. They do not need to match the _rendered_ size of the image but should be set at reasonable upper bounds.
+- **Do** understand that the `fallbackHeight` and `fallbackWidth` props are [used to set aspect ratio and help the browser reserve space](https://blog.logrocket.com/jank-free-page-loading-with-media-aspect-ratios/) for the image during initial layout.
 - **Do** [provide useful alt text](https://www.w3.org/WAI/tutorials/images/decision-tree/) for your images. Sometimes, an empty string is the most useful!
 - **Do** learn why and how to use [responsive rendering](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images). It’s important to understand how `sizes` and `srcSet` work.
-- **Do** think about AMP when using the `Image` component and pass the correct `amp` prop.
+- **Do** think when and whether this component might be rendered on AMP pages and pass the correct `amp` prop.
 - **Do not** avoid the `Image` component by using the HTML `img` tag. The `Image` component enforces best practices and performant rendering.
 - **Do not** use the `Image` component for SVGs. Instead, import SVGs and render them directly with React.
 

--- a/src/components/Image/Image.docs.mdx
+++ b/src/components/Image/Image.docs.mdx
@@ -1,0 +1,42 @@
+import { Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import Image from './Image';
+
+# Image
+
+Displays an image. The `Image` component requires `height` and `width` to set aspect ratio and `sizes` and `srcSet` to provide [responsive rendering](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images). They will not be calculated for you and there are no default values. Future components may provide a simpler implementation for specific use cases.
+
+This component does not provide [art direction](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture), which is also a task for a future component.
+
+## Usage
+
+```js
+import { Image } from '@quartz/interface/src/components';
+```
+
+## Props
+
+<Props of={Image} />
+
+## Usage guidelines
+
+- **Do** use a container to constrain the size or shape of the image. An `Image` will always expand or contract to fit the width of its container. The `Image` component purposefully does not accept a `className` prop.
+- **Do** understand that the `height` and `width` props are [used to help the browser reserve space](https://blog.logrocket.com/jank-free-page-loading-with-media-aspect-ratios/) for the image. They do not need to match the _rendered_ size of the image but should be set at reasonable upper bounds.
+- **Do** [provide useful alt text](https://www.w3.org/WAI/tutorials/images/decision-tree/) for your images. Sometimes, an empty string is the most useful!
+- **Do** learn why and how to use [responsive rendering](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images). It’s important to understand how `sizes` and `srcSet` work.
+- **Do** think about AMP when using the `Image` component and pass the correct `amp` prop.
+- **Do not** avoid the `Image` component by using the HTML `img` tag. The `Image` component enforces best practices and performant rendering.
+- **Do not** use the `Image` component for SVGs. Instead, import SVGs and render them directly with React.
+
+## Examples
+
+### An image constrained to 400px
+
+<Preview>
+  <Story id="image--constrained" />
+</Preview>
+
+### An image constrained to 200px and reshaped to be round
+
+<Preview>
+  <Story id="image--reshaped" />
+</Preview>

--- a/src/components/Image/Image.jsx
+++ b/src/components/Image/Image.jsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './Image.scss';
+
+function ImageAmp ( {
+	alt,
+	height,
+	sizes,
+	src,
+	srcSet,
+	title,
+	width,
+} ) {
+	return (
+		<amp-img
+			alt={alt}
+			height="1"
+			layout="responsive"
+			sizes={sizes}
+			src={src}
+			srcSet={srcSet}
+			title={title}
+			width={width / height}
+		/>
+	);
+};
+
+ImageAmp.propTypes = {
+	alt: PropTypes.string.isRequired,
+	height: PropTypes.number.isRequired,
+	sizes: PropTypes.string.isRequired,
+	src: PropTypes.string.isRequired,
+	srcSet: PropTypes.string.isRequired,
+	title: PropTypes.string,
+	width: PropTypes.number.isRequired,
+};
+
+function Image ( {
+	alt,
+	amp,
+	height,
+	loading,
+	sizes,
+	src,
+	srcSet,
+	title,
+	width,
+} ) {
+	if ( amp ) {
+		return (
+			<ImageAmp
+				alt={alt}
+				height={1}
+				sizes={sizes}
+				src={src}
+				srcSet={srcSet}
+				title={title}
+				width={width / height}
+			/>
+		);
+	}
+
+	return (
+		<img
+			alt={alt}
+			className={styles.image}
+			decoding="async"
+			height={height}
+			loading={loading}
+			sizes={sizes}
+			src={src}
+			srcSet={srcSet}
+			title={title}
+			width={width}
+		/>
+	);
+};
+
+Image.propTypes = {
+	/**
+	 * Alternative text to describe the image for screen readers or in situations
+	 * where the image cannot be loaded. This prop is required but under certain
+	 * circumstances an empty string is preferred.
+	 */
+	alt: PropTypes.string.isRequired,
+
+	/**
+	 * Whether to render the AMP version of the image.
+	 */
+	amp: PropTypes.bool.isRequired,
+
+	/**
+	 * The height of the image. The absolute value is not as important as its
+	 * correspondences with the `width` prop to set the correct aspect ratio. A
+	 * good practice is to set this at the largest size at which this image can be
+	 * rendered.
+	 */
+	height: PropTypes.number.isRequired,
+
+	/**
+	 * How and when the image should be loaded—e.g., right away or only after the
+	 * image is revealed in the viewport.
+	 */
+	loading: PropTypes.oneOf( [ 'auto', 'eager', 'lazy' ] ).isRequired,
+
+	/**
+	 * The responsize `img` sizes attribute.
+	 */
+	sizes: PropTypes.string.isRequired,
+
+	/**
+	 * The fallback `img` src attribute.
+	 */
+	src: PropTypes.string.isRequired,
+
+	/**
+	 * The response `img` srcSet attribute.
+	 */
+	srcSet: PropTypes.string.isRequired,
+
+	/**
+	 * The `img` title attribute.
+	 */
+	title: PropTypes.string,
+
+	/**
+	 * The width of the image. The absolute value is not as important as its
+	 * correspondence with the `height` prop to set the correct aspect ratio. A
+	 * good practice is to set this at the largest size at which this image can be
+	 * rendered.
+	 */
+	width: PropTypes.number.isRequired,
+};
+
+Image.defaultProps = {
+	amp: false,
+	loading: 'lazy',
+};
+
+export default Image;

--- a/src/components/Image/Image.jsx
+++ b/src/components/Image/Image.jsx
@@ -38,13 +38,13 @@ ImageAmp.propTypes = {
 function Image ( {
 	alt,
 	amp,
-	height,
+	fallbackHeight: height,
+	fallbackWidth: width,
 	loading,
 	sizes,
 	src,
 	srcSet,
 	title,
-	width,
 } ) {
 	if ( amp ) {
 		return (
@@ -90,16 +90,23 @@ Image.propTypes = {
 	amp: PropTypes.bool.isRequired,
 
 	/**
-	 * The height of the image. The absolute value is not as important as its
-	 * correspondences with the `width` prop to set the correct aspect ratio. A
-	 * good practice is to set this at the largest size at which this image can be
-	 * rendered.
+	 * The rendered height of the image when CSS cannot be loaded or in very old
+	 * browsers. With `fallbackWidth`, it sets the aspect ratio for the image.
+	 * Therefore, it's critical to provide an accurate value. A good practice is
+	 * to set this at the largest size at which this image can be rendered.
 	 */
-	height: PropTypes.number.isRequired,
+	fallbackHeight: PropTypes.number.isRequired,
 
 	/**
-	 * How and when the image should be loaded—e.g., right away or only after the
-	 * image is revealed in the viewport.
+	 * The rendered width of the image when CSS cannot be loaded or in very old
+	 * browsers. See `fallbackHeight`.
+	 */
+	fallbackWidth: PropTypes.number.isRequired,
+
+	/**
+	 * How and when the image should be loaded. See
+	 * [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img) for
+	 * details on allowed values and their behavior.
 	 */
 	loading: PropTypes.oneOf( [ 'auto', 'eager', 'lazy' ] ).isRequired,
 
@@ -122,14 +129,6 @@ Image.propTypes = {
 	 * The `img` title attribute.
 	 */
 	title: PropTypes.string,
-
-	/**
-	 * The width of the image. The absolute value is not as important as its
-	 * correspondence with the `height` prop to set the correct aspect ratio. A
-	 * good practice is to set this at the largest size at which this image can be
-	 * rendered.
-	 */
-	width: PropTypes.number.isRequired,
 };
 
 Image.defaultProps = {

--- a/src/components/Image/Image.scss
+++ b/src/components/Image/Image.scss
@@ -1,0 +1,5 @@
+.image {
+	display: block;
+	height: auto;
+	width: 100%;
+}

--- a/src/components/Image/Image.story.jsx
+++ b/src/components/Image/Image.story.jsx
@@ -14,7 +14,8 @@ export const Constrained = () => (
 	<div style={{ maxWidth: 400 }}>
 		<Image
 			alt="A studio portrait of Lena Waithe"
-			height={400}
+			fallbackHeight={400}
+			fallbackWidth={400}
 			sizes="(max-width: 200px) 200w, 400w"
 			src="https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=400&h=400&crop=1"
 			srcSet="
@@ -23,7 +24,6 @@ export const Constrained = () => (
 				https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=400&h=400&crop=1 400w 1x,
 				https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=800&h=800&crop=1 400w 2x
 			"
-			width={400}
 		/>
 	</div>
 );
@@ -32,7 +32,8 @@ export const Reshaped = () => (
 	<div style={{ borderRadius: '50%', maxWidth: 200, overflow: 'hidden' }}>
 		<Image
 			alt="A studio portrait of Lena Waithe"
-			height={400}
+			fallbackHeight={400}
+			fallbackWidth={400}
 			sizes="(max-width: 100px) 100w, 200w"
 			src="https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=400&h=400&crop=1"
 			srcSet="
@@ -41,7 +42,6 @@ export const Reshaped = () => (
 				https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=200&h=200&crop=1 200w 1x,
 				https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=400&h=400&crop=1 200w 2x
 			"
-			width={400}
 		/>
 	</div>
 );

--- a/src/components/Image/Image.story.jsx
+++ b/src/components/Image/Image.story.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import Image from './Image';
+import docs from './Image.docs.mdx';
+
+export default {
+	title: 'Image',
+	component: Image,
+	parameters: {
+		docs: { page: docs },
+	},
+};
+
+export const Constrained = () => (
+	<div style={{ maxWidth: 400 }}>
+		<Image
+			alt="A studio portrait of Lena Waithe"
+			height={400}
+			sizes="(max-width: 200px) 200w, 400w"
+			src="https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=400&h=400&crop=1"
+			srcSet="
+				https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=200&h=200&crop=1 200w 1x,
+				https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=400&h=400&crop=1 200w 2x,
+				https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=400&h=400&crop=1 400w 1x,
+				https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=800&h=800&crop=1 400w 2x
+			"
+			width={400}
+		/>
+	</div>
+);
+
+export const Reshaped = () => (
+	<div style={{ borderRadius: '50%', maxWidth: 200, overflow: 'hidden' }}>
+		<Image
+			alt="A studio portrait of Lena Waithe"
+			height={400}
+			sizes="(max-width: 100px) 100w, 200w"
+			src="https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=400&h=400&crop=1"
+			srcSet="
+				https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=100&h=100&crop=1 100w 1x,
+				https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=200&h=200&crop=1 100w 2x,
+				https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=200&h=200&crop=1 200w 1x,
+				https://cms.qz.com/wp-content/uploads/2018/01/lenawaithe-portrait.jpg?quality=75&strip=all&w=400&h=400&crop=1 200w 2x
+			"
+			width={400}
+		/>
+	</div>
+);

--- a/src/components/Image/Image.test.js
+++ b/src/components/Image/Image.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Image from './Image';
+
+const defaultProps = {
+	alt: '',
+	amp: false,
+	height: 100,
+	sizes: '200w',
+	src: 'https://example.com/cheezburger@100.jpeg',
+	srcSet: 'https://example.com/cheezburger@200.jpeg 200w',
+	width: 200,
+};
+
+const setup = overrides => shallow( <Image {...defaultProps} {...overrides} /> );
+
+describe( 'Image', () => {
+	it( 'renders an img by default', () => {
+		const wrapper = setup();
+
+		expect( wrapper.find( 'ImageAmp' ) ).toHaveLength( 0 );
+		expect( wrapper.find( 'img' ) ).toHaveLength( 1 );
+
+		expect( wrapper.find( 'img' ).props().src ).toEqual( defaultProps.src );
+	} );
+
+	it( 'renders an AMP img when amp is true', () => {
+		const wrapper = setup( { amp: true } );
+
+		expect( wrapper.find( 'img' ) ).toHaveLength( 0 );
+		expect( wrapper.find( 'ImageAmp' ) ).toHaveLength( 1 );
+
+		expect( wrapper.find( 'ImageAmp' ).props().src ).toEqual( defaultProps.src );
+	} );
+} );
+

--- a/src/components/Image/Image.test.js
+++ b/src/components/Image/Image.test.js
@@ -5,11 +5,11 @@ import Image from './Image';
 const defaultProps = {
 	alt: '',
 	amp: false,
-	height: 100,
+	fallbackHeight: 100,
+	fallbackWidth: 100,
 	sizes: '200w',
 	src: 'https://example.com/cheezburger@100.jpeg',
 	srcSet: 'https://example.com/cheezburger@200.jpeg 200w',
-	width: 200,
 };
 
 const setup = overrides => shallow( <Image {...defaultProps} {...overrides} /> );

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,6 +1,7 @@
 export { default as Button, ButtonLink } from './Button/Button';
 export { default as CalloutCard } from './CalloutCard/CalloutCard';
 export { default as Checkbox } from './Checkbox/Checkbox';
+export { default as Image } from './Image/Image';
 export { default as Link } from './Link/Link';
 export { default as RadioButton } from './RadioButton/RadioButton';
 export { default as Spinner } from './Spinner/Spinner';


### PR DESCRIPTION
This is a pretty barebones `Image` component—no art direction and no calculated `sizes` and `srcSet`.

- The image expands and contracts to fit the container and allows no custom styling.
- Width and height are required to allow the browser to reserve space during layout. I'm mostly following the principles outlined in [this article](https://blog.logrocket.com/jank-free-page-loading-with-media-aspect-ratios/).
- Leveraging `loading=lazy` instead of a JS lazy-loading solution.

I think a small, unopinionated `Image` component is a good building block for other image components. However, I also think we tend to overestimate the utility of very narrow image components that end up being used fairly infrequently.