### PR TITLE
TextGroup, Hed, Kicker, and Tagline components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4436,8 +4436,8 @@
       }
     },
     "@quartz/styles": {
-      "version": "git+https://github.com/Quartz/styles.git#9090a0024e297456ff42c9a0601c4be787db0fd5",
-      "from": "git+https://github.com/Quartz/styles.git#9090a00",
+      "version": "git+https://github.com/Quartz/styles.git#4a94e3d73ae71024e6477e65fc4d2396872bf559",
+      "from": "git+https://github.com/Quartz/styles.git#4a94e3d",
       "dev": true,
       "requires": {
         "normalize.css": "^8.0.1"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"@babel/preset-react": "^7.10.4",
 		"@quartz/eslint-config-react": "^1.0.4",
 		"@quartz/stylelint-config": "^1.0.0",
-		"@quartz/styles": "git+https://github.com/Quartz/styles.git#9090a00",
+		"@quartz/styles": "git+https://github.com/Quartz/styles.git#4a94e3d",
 		"@storybook/addon-a11y": "^5.3.19",
 		"@storybook/addon-actions": "^5.3.19",
 		"@storybook/addon-docs": "^5.3.19",

--- a/src/components/Hed/Hed.docs.mdx
+++ b/src/components/Hed/Hed.docs.mdx
@@ -1,0 +1,24 @@
+import { Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import Hed from './Hed';
+
+# Hed
+
+A hed (short for headline) is the title of a story or unit of content. This component is not exported for direct use; instead, it is composed into other components that provide information about a story.
+
+## Props
+
+<Props of={Hed} />
+
+## Examples
+
+### Small
+
+<Preview>
+  <Story id="hed--small" />
+</Preview>
+
+### Large
+
+<Preview>
+  <Story id="hed--large" />
+</Preview>

--- a/src/components/Hed/Hed.jsx
+++ b/src/components/Hed/Hed.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './Hed.scss';
+
+function Hed ( {
+	children,
+	size,
+} ) {
+	return (
+		<div className={`${styles.container} ${styles[ size ]}`}>
+			{children}
+		</div>
+	);
+};
+
+Hed.propTypes = {
+	/**
+	 * The text of the headline.
+	 */
+	children: PropTypes.node.isRequired,
+
+	/**
+	 * The size of the headline.
+	 */
+	size: PropTypes.oneOf( [ 'large', 'small' ] ).isRequired,
+};
+
+Hed.defaultProps = {
+	size: 'large',
+};
+
+export default Hed;

--- a/src/components/Hed/Hed.scss
+++ b/src/components/Hed/Hed.scss
@@ -1,0 +1,15 @@
+@import '~@quartz/styles/scss/color-scheme';
+@import '~@quartz/styles/scss/fonts';
+
+.container {
+	color: $color-typography;
+	margin: 0;
+}
+
+.small {
+	@include font-maison-800-4;
+}
+
+.large {
+	@include font-maison-800-7;
+}

--- a/src/components/Hed/Hed.story.jsx
+++ b/src/components/Hed/Hed.story.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Hed from './Hed';
+import docs from './Hed.docs.mdx';
+
+export default {
+	title: 'Hed',
+	component: Hed,
+	parameters: {
+		docs: { page: docs },
+	},
+};
+
+export const Small = () => (
+	<Hed size="small">All the “wellness” products Americans love to buy are sold on both Infowars and Goop</Hed>
+);
+
+export const Large = () => (
+	<Hed size="large">All the “wellness” products Americans love to buy are sold on both Infowars and Goop</Hed>
+);

--- a/src/components/Kicker/Kicker.docs.mdx
+++ b/src/components/Kicker/Kicker.docs.mdx
@@ -1,0 +1,20 @@
+import { Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import Kicker from './Kicker';
+
+# Kicker
+
+A kicker is a short phrase that accompanies the [hed](/?path=/docs/hed--small#hed) of a story or unit of content. This component is not exported for direct use; instead, it is composed into other components that provide information about a story.
+
+Interestingly, the word ”kicker” is [undergoing some change](https://www.merriam-webster.com/words-at-play/kicker-definition-meaning) even within journalism circles, so it’s not uncommon to encounter someone who is confused by how we employ ”kickers” at Quartz.
+
+## Props
+
+<Props of={Kicker} />
+
+## Examples
+
+### Default
+
+<Preview>
+  <Story id="kicker--default" />
+</Preview>

--- a/src/components/Kicker/Kicker.jsx
+++ b/src/components/Kicker/Kicker.jsx
@@ -4,10 +4,9 @@ import styles from './Kicker.scss';
 
 function Kicker ( {
 	children,
-	type,
 } ) {
 	return (
-		<div className={`${styles.container} ${styles[ type ]}`}>
+		<div className={styles.container}>
 			{children}
 		</div>
 	);
@@ -18,15 +17,6 @@ Kicker.propTypes = {
 	 * The text of the kicker.
 	 */
 	children: PropTypes.node.isRequired,
-
-	/**
-	 * The kicker type, which influences color and other formatting.
-	 */
-	type: PropTypes.oneOf( [ 'article', 'bulletin', 'default' ] ),
-};
-
-Kicker.defaultProps = {
-	type: 'default',
 };
 
 export default Kicker;

--- a/src/components/Kicker/Kicker.jsx
+++ b/src/components/Kicker/Kicker.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './Kicker.scss';
+
+function Kicker ( {
+	children,
+	type,
+} ) {
+	return (
+		<div className={`${styles.container} ${styles[ type ]}`}>
+			{children}
+		</div>
+	);
+};
+
+Kicker.propTypes = {
+	/**
+	 * The text of the kicker.
+	 */
+	children: PropTypes.node.isRequired,
+
+	/**
+	 * The kicker type, which influences color and other formatting.
+	 */
+	type: PropTypes.oneOf( [ 'article', 'bulletin', 'default' ] ),
+};
+
+Kicker.defaultProps = {
+	type: 'default',
+};
+
+export default Kicker;
+

--- a/src/components/Kicker/Kicker.scss
+++ b/src/components/Kicker/Kicker.scss
@@ -1,0 +1,8 @@
+@import '~@quartz/styles/scss/color-scheme';
+@import '~@quartz/styles/scss/fonts';
+
+.container {
+	@include font-maison-extended-700-1;
+
+	text-transform: uppercase;
+}

--- a/src/components/Kicker/Kicker.scss
+++ b/src/components/Kicker/Kicker.scss
@@ -3,6 +3,4 @@
 
 .container {
 	@include font-maison-extended-700-1;
-
-	text-transform: uppercase;
 }

--- a/src/components/Kicker/Kicker.story.jsx
+++ b/src/components/Kicker/Kicker.story.jsx
@@ -13,11 +13,3 @@ export default {
 export const Default = () => (
 	<Kicker>Neither Here Nor There</Kicker>
 );
-
-export const Article = () => (
-	<Kicker type="article">Neither Here Nor There</Kicker>
-);
-
-export const Bulletin = () => (
-	<Kicker type="bulletin">Neither Here Nor There</Kicker>
-);

--- a/src/components/Kicker/Kicker.story.jsx
+++ b/src/components/Kicker/Kicker.story.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Kicker from './Kicker';
+import docs from './Kicker.docs.mdx';
+
+export default {
+	title: 'Kicker',
+	component: Kicker,
+	parameters: {
+		docs: { page: docs },
+	},
+};
+
+export const Default = () => (
+	<Kicker>Neither Here Nor There</Kicker>
+);
+
+export const Article = () => (
+	<Kicker type="article">Neither Here Nor There</Kicker>
+);
+
+export const Bulletin = () => (
+	<Kicker type="bulletin">Neither Here Nor There</Kicker>
+);

--- a/src/components/Tagline/Tagline.docs.mdx
+++ b/src/components/Tagline/Tagline.docs.mdx
@@ -1,0 +1,24 @@
+import { Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import Tagline from './Tagline';
+
+# Tagline
+
+A tagline is a short description or introduction that accompanies the [hed](/?path=/docs/hed--small#hed) of a story. It might also be used to implement a dateline. This component is not exported for direct use; instead, it is composed into other components that provide information about a story.
+
+## Props
+
+<Props of={Tagline} />
+
+## Examples
+
+### Default
+
+<Preview>
+  <Story id="tagline--default" />
+</Preview>
+
+### Dateline
+
+<Preview>
+  <Story id="tagline--dateline" />
+</Preview>

--- a/src/components/Tagline/Tagline.jsx
+++ b/src/components/Tagline/Tagline.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './Tagline.scss';
+
+function Tagline ( {
+	children,
+} ) {
+	return (
+		<div className={styles.container}>
+			{children}
+		</div>
+	);
+};
+
+Tagline.propTypes = {
+	/**
+	 * The text of the kicker.
+	 */
+	children: PropTypes.node.isRequired,
+};
+
+export default Tagline;
+

--- a/src/components/Tagline/Tagline.scss
+++ b/src/components/Tagline/Tagline.scss
@@ -5,5 +5,4 @@
 	@include font-maison-500-1;
 
 	color: $color-typography-faint;
-	line-height: 1;
 }

--- a/src/components/Tagline/Tagline.scss
+++ b/src/components/Tagline/Tagline.scss
@@ -1,0 +1,9 @@
+@import '~@quartz/styles/scss/color-scheme';
+@import '~@quartz/styles/scss/fonts';
+
+.container {
+	@include font-maison-500-1;
+
+	color: $color-typography-faint;
+	line-height: 1;
+}

--- a/src/components/Tagline/Tagline.story.jsx
+++ b/src/components/Tagline/Tagline.story.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Tagline from './Tagline';
+import docs from './Tagline.docs.mdx';
+
+export default {
+	title: 'Tagline',
+	component: Tagline,
+	parameters: {
+		docs: { page: docs },
+	},
+};
+
+export const Default = () => (
+	<Tagline>The next big battles in tech.</Tagline>
+);
+
+export const Dateline = () => (
+	<Tagline>3 days ago • Quartz Africa</Tagline>
+);

--- a/src/components/TextGroup/TextGroup.docs.mdx
+++ b/src/components/TextGroup/TextGroup.docs.mdx
@@ -1,0 +1,43 @@
+import { Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import TextGroup from './TextGroup';
+
+# TextGroup
+
+A basic promotional unit that groups textual elements to describe a piece of
+content. Most `TextGroup`s are wrapped in `Link`s that take the user to the
+described content.
+
+## Usage
+
+```js
+import { TextGroup } from '@quartz/interface/src/components';
+```
+
+## Props
+
+<Props of={TextGroup} />
+
+## Usage guidelines
+
+- **Do** use a container to constrain the size of the `TextGroup`.
+- **Do not** use the `TextGroup` component to represent things that are not Quartz content.
+
+## Examples
+
+### A taxonomy
+
+<Preview>
+  <Story id="textgroup--default" />
+</Preview>
+
+### An article
+
+<Preview>
+  <Story id="textgroup--article" />
+</Preview>
+
+### A special project
+
+<Preview>
+  <Story id="textgroup--no-kicker" />
+</Preview>

--- a/src/components/TextGroup/TextGroup.jsx
+++ b/src/components/TextGroup/TextGroup.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Hed from '../Hed/Hed';
+import Kicker from '../Kicker/Kicker';
+import Tagline from '../Tagline/Tagline';
+import styles from './TextGroup.scss';
+
+function TextGroup ( {
+	kicker,
+	tagline,
+	title,
+	type,
+} ) {
+	return (
+		<>
+			{
+				kicker &&
+					<Kicker>
+						<div className={`${styles.kicker} ${styles[ `kicker-${type}` ]}`}>{kicker}</div>
+					</Kicker>
+			}
+			<Hed size="small">{title}</Hed>
+			{
+				tagline &&
+					<Tagline>
+						<div className={styles.tagline}>{tagline}</div>
+					</Tagline>
+			}
+		</>
+	);
+};
+
+TextGroup.propTypes = {
+	/**
+	 * Kicker text. This accepts a string or a node—most notably to accommodate
+	 * bulletins, which have multicolor kickers and sometimes incorporate images.
+	 */
+	kicker: PropTypes.node,
+
+	/**
+	 * Tagline to appear beneath the title.
+	 */
+	tagline: PropTypes.string,
+
+	/**
+	 * Title.
+	 */
+	title: PropTypes.string.isRequired,
+
+	/**
+	 * The type of the text group, which influences color and other formatting.
+	 */
+	type: PropTypes.oneOf( [ 'article', 'default' ] ),
+};
+
+TextGroup.defaultProps = {
+	type: 'default',
+};
+
+export default TextGroup;

--- a/src/components/TextGroup/TextGroup.scss
+++ b/src/components/TextGroup/TextGroup.scss
@@ -8,10 +8,6 @@
 	color: $color-accent;
 }
 
-.kicker-bulletin {
-	color: $color-gold;
-}
-
 .kicker-default {
 	color: $color-typography-faint;
 }

--- a/src/components/TextGroup/TextGroup.scss
+++ b/src/components/TextGroup/TextGroup.scss
@@ -1,0 +1,21 @@
+@import '~@quartz/styles/scss/color-scheme';
+
+.kicker {
+	margin-bottom: 5px;
+}
+
+.kicker-article {
+	color: $color-accent;
+}
+
+.kicker-bulletin {
+	color: $color-gold;
+}
+
+.kicker-default {
+	color: $color-typography-faint;
+}
+
+.tagline {
+	margin-top: 5px;
+}

--- a/src/components/TextGroup/TextGroup.story.jsx
+++ b/src/components/TextGroup/TextGroup.story.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import TextGroup from './TextGroup';
+import docs from './TextGroup.docs.mdx';
+
+export default {
+	title: 'TextGroup',
+	component: TextGroup,
+	parameters: {
+		docs: { page: docs },
+	},
+};
+
+export const Default = () => (
+	<div style={{ maxWidth: 400 }}>
+		<TextGroup
+			kicker="From our Guide"
+			tagline="Which unicorns will fade and which are here to stay."
+			title="Beyond the fintech hype"
+		/>
+	</div>
+);
+
+export const Article = () => (
+	<div style={{ maxWidth: 400 }}>
+		<TextGroup
+			kicker="Lightning Goals"
+			tagline="Oct. 12, 2018 • Quartz"
+			title="Usain Bolt is slowly but surely becoming a soccer player"
+			type="article"
+		/>
+	</div>
+);
+
+export const NoKicker = () => (
+	<div style={{ maxWidth: 400 }}>
+		<TextGroup
+			tagline="Coronavirus has changed the world. Here’s how experts think it will affect our lives in five years."
+			title="The New Normal"
+		/>
+	</div>
+);

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -5,3 +5,4 @@ export { default as Image } from './Image/Image';
 export { default as Link } from './Link/Link';
 export { default as RadioButton } from './RadioButton/RadioButton';
 export { default as Spinner } from './Spinner/Spinner';
+export { default as TextGroup } from './TextGroup/TextGroup';


### PR DESCRIPTION
Inching towards a module I can use for a current ticket. This introduces "private" components `Hed`, `Kicker`, and `Tagline` that can be composed into other components. 

The first of these assembled components is `TextGroup`, which implements an extremely common pattern that we use in feeds, dropdowns, tables of contents, and promotional modules.

<img width="881" alt="Screen Shot 2020-08-11 at 5 09 52 PM" src="https://user-images.githubusercontent.com/739304/89949454-f01b1a80-dbf5-11ea-9348-3aec7952bd86.png">
