### PR TITLE
Add Example component and copy script

### DIFF
--- a/copy.sh
+++ b/copy.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+	echo "Please provide a source and target component name:"
+	echo "npm run copy OldComponent NewComponent"
+	exit 1
+fi
+
+mkdir -p "./src/components/$2"
+
+files=(
+	'docs.mdx'
+	'jsx'
+	'scss'
+	'story.jsx'
+	'test.js'
+)
+for file in "${files[@]}"; do
+	source="./src/components/$1/$1.$file"
+	dest="./src/components/$2/$2.$file"
+
+	if [ ! -f "$source" ]; then
+		echo "$1.$file does not exist, skipping...."
+	elif [ -f "$dest" ]; then
+		echo "$2.$file already exists, skipping...."
+	else
+		sed -e "s/$1/$2/g" "$source" > "$dest"
+	fi
+done
+

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"node": ">=10.9"
 	},
 	"scripts": {
+		"copy": "./copy.sh",
 		"start": "start-storybook -s public",
 		"build": "build-storybook -o .storybook/build -s public",
 		"eslint": "eslint --ext .js,.jsx --ignore-path .gitignore --ignore-pattern backstop_data . --ignore-pattern bundles.js",

--- a/src/components/Example/Example.docs.mdx
+++ b/src/components/Example/Example.docs.mdx
@@ -1,0 +1,40 @@
+import { Story, Preview, Props } from '@storybook/addon-docs/blocks';
+import Example from './Example';
+
+# Example
+
+An example component that can be used as a template for new components. A script
+is provided to copy this component to a new one, renaming everything
+appropriately:
+
+```sh
+npm run copy Example NewComponent
+```
+
+This script can also be used to copy any existing component, just replace
+`Example` with the name of another component.
+
+## Usage
+
+```js
+import { Example } from '@quartz/interface/src/components';
+```
+
+## Props
+
+<Props of={Example} />
+
+## Usage guidelines
+
+- **Do** update the `Example` component if you make improvements that other components could benefit from.
+- **Do not** use the `Example` component.
+
+## Examples
+
+### Default
+
+<Preview>
+  <Story id="example--default" />
+</Preview>
+
+

--- a/src/components/Example/Example.jsx
+++ b/src/components/Example/Example.jsx
@@ -10,13 +10,13 @@ function Example ( {
 
 Example.propTypes = {
 	/**
-	 * Text
+	 * Child node to be rendered as the inner HTML of the component.
 	 */
-	text: PropTypes.string.isRequired,
+	children: PropTypes.node.isRequired,
 };
 
 Example.defaultProps = {
-	text: 'Hello, world!',
+	children: 'Hello, world!',
 };
 
 export default Example;

--- a/src/components/Example/Example.jsx
+++ b/src/components/Example/Example.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styles from './Example.scss';
 
 function Example ( {
-	text,
+	children,
 } ) {
 	return <div className={styles.container}>{children}</div>;
 }

--- a/src/components/Example/Example.jsx
+++ b/src/components/Example/Example.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './Example.scss';
+
+function Example ( {
+	text,
+} ) {
+	return <div className={styles.container}>{text}</div>;
+}
+
+Example.propTypes = {
+	/**
+	 * Text
+	 */
+	text: PropTypes.string.isRequired,
+};
+
+Example.defaultProps = {
+	text: 'Hello, world!',
+};
+
+export default Example;

--- a/src/components/Example/Example.jsx
+++ b/src/components/Example/Example.jsx
@@ -5,7 +5,7 @@ import styles from './Example.scss';
 function Example ( {
 	text,
 } ) {
-	return <div className={styles.container}>{text}</div>;
+	return <div className={styles.container}>{children}</div>;
 }
 
 Example.propTypes = {

--- a/src/components/Example/Example.scss
+++ b/src/components/Example/Example.scss
@@ -1,0 +1,3 @@
+.container {
+	padding: 10px;
+}

--- a/src/components/Example/Example.story.jsx
+++ b/src/components/Example/Example.story.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Example from './Example';
+import docs from './Example.docs.mdx';
+
+export default {
+	title: 'Example',
+	component: Example,
+	parameters: {
+		docs: { page: docs },
+	},
+};
+
+export const Default = () => <Example />;

--- a/src/components/Example/Example.test.js
+++ b/src/components/Example/Example.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import Example from './Example';
 
 const defaultProps = {
-	text: 'Test content',
+	children: 'Test content',
 };
 
 const setup = overrides => shallow( <Example {...defaultProps} {...overrides} /> );
@@ -15,4 +15,3 @@ describe( 'Example', () => {
 		expect( wrapper.text() ).toEqual( 'Test content' );
 	} );
 } );
-

--- a/src/components/Example/Example.test.js
+++ b/src/components/Example/Example.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Example from './Example';
+
+const defaultProps = {
+	text: 'Test content',
+};
+
+const setup = overrides => shallow( <Example {...defaultProps} {...overrides} /> );
+
+describe( 'Example', () => {
+	it( 'renders', () => {
+		const wrapper = setup();
+
+		expect( wrapper.text() ).toEqual( 'Test content' );
+	} );
+} );
+


### PR DESCRIPTION
Scaffolding new components can be a bit of a chore, whether you start from scratch or copy an existing component. In particular, I got tired of renaming files and replacing component names, especially when I'd change my mind a few times when decided what to call a component.

This PR introduces an `Example` component that can be used as a template and a copy script that automates the process of renaming and replacing:

```
npm run copy Example NewComponent
```

You can also copy an existing "real" component:

```
npm run copy Button CTA
```