### PR TITLE
Add missing default prop for Button.inline

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -146,6 +146,7 @@ Button.propTypes = {
 
 Button.defaultProps = {
 	disabled: false,
+	inline: false,
 	loading: false,
 	onClick: () => {},
 	type: 'button',


### PR DESCRIPTION
In https://github.com/Quartz/interface/pull/24 I made `Button.propTypes.inline` a required prop but failed to provide a default
