### PR TITLE
Remove MemoryRouter wrapper from app decorator component

### DIFF
--- a/.storybook/addons/MockAppDecorator/MockAppDecorator.jsx
+++ b/.storybook/addons/MockAppDecorator/MockAppDecorator.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MemoryRouter } from 'react-router-dom';
 import '!style-loader!css-loader!sass-loader!./MockAppDecorator.scss';
 
 /*
@@ -11,9 +10,7 @@ import '!style-loader!css-loader!sass-loader!./MockAppDecorator.scss';
 	https://storybook.js.org/docs/addons/introduction/#1-decorators
 */
 const MockAppDecorator = ( { children } ) => (
-	<MemoryRouter>
-		<main className="fonts-loaded">{children}</main>
-	</MemoryRouter>
+	<main className="fonts-loaded">{children}</main>
 );
 
 MockAppDecorator.propTypes = {


### PR DESCRIPTION
I removed `react-router-dom` as a dependency in https://github.com/Quartz/interface/pull/24, but forgot to remove `MemoryWrapper` from the mock app decorator component.