### PR TITLE
Add size preset prop to TextGroup

### DIFF
--- a/src/components/BadgeGroup/BadgeGroup.jsx
+++ b/src/components/BadgeGroup/BadgeGroup.jsx
@@ -26,7 +26,7 @@ function BadgeGroup ( {
 			<div className={styles.text}>
 				<TextGroup
 					kicker={kicker}
-					size={size === 'large' ? 'medium' : 'small'}
+					size={size}
 					tagline={tagline}
 					title={title}
 				/>
@@ -53,9 +53,10 @@ BadgeGroup.propTypes = {
 	kicker: PropTypes.node,
 
 	/**
-	 * Size preset. Adjusts the size of the headline (Hed component).
+	 * Size preset. Adjusts the size of the TextGroup (see
+	 * `TextGroup.propTypes.size`).
 	 */
-	size: PropTypes.oneOf( [ 'small', 'large' ] ),
+	size: PropTypes.oneOf( [ 'small', 'medium' ] ),
 
 	/**
 	 * Tagline to appear beneath the title.

--- a/src/components/BadgeGroup/BadgeGroup.jsx
+++ b/src/components/BadgeGroup/BadgeGroup.jsx
@@ -7,6 +7,7 @@ import styles from './BadgeGroup.scss';
 function BadgeGroup ( {
 	imageUrl,
 	kicker,
+	size,
 	tagline,
 	title,
 } ) {
@@ -25,6 +26,7 @@ function BadgeGroup ( {
 			<div className={styles.text}>
 				<TextGroup
 					kicker={kicker}
+					size={size === 'large' ? 'medium' : 'small'}
 					tagline={tagline}
 					title={title}
 				/>
@@ -51,6 +53,11 @@ BadgeGroup.propTypes = {
 	kicker: PropTypes.node,
 
 	/**
+	 * Size preset. Adjusts the size of the headline (Hed component).
+	 */
+	size: PropTypes.oneOf( [ 'small', 'large' ] ),
+
+	/**
 	 * Tagline to appear beneath the title.
 	 */
 	tagline: PropTypes.string,
@@ -59,6 +66,10 @@ BadgeGroup.propTypes = {
 	 * Title.
 	 */
 	title: PropTypes.string.isRequired,
+};
+
+BadgeGroup.defaultProps = {
+	size: 'small',
 };
 
 export default BadgeGroup;

--- a/src/components/BadgeGroup/BadgeGroup.stories.mdx
+++ b/src/components/BadgeGroup/BadgeGroup.stories.mdx
@@ -33,17 +33,57 @@ A `BadgeGroup` is a <LinkTo kind="TextGroup">TextGroup</LinkTo> accompanied by a
 
 ## Stories
 
-### Wrapping tagline
+### Small
+
+<Canvas>
+	<Story
+		args={{
+			imageUrl: 'https://cms.qz.com/wp-content/uploads/2020/06/NewNormal-Promo.png?w=51&h=51&crop=1&strip=all&quality=75',
+			tagline: 'Coronavirus has changed the world. Here’s how experts think it will affect our lives in five years.',
+			title: 'The New Normal',
+		}}
+		name="Small"
+		size="large"
+	>
+		{args => (
+			<div style={{ maxWidth: 400 }}>
+				<BadgeGroup {...args} />
+			</div>
+		)}
+	</Story>
+</Canvas>
+
+### Small with no badge
+
+<Canvas>
+	<Story
+		args={{
+			tagline: 'Quartz is a guide to the new global economy for people in business who are excited by change. We cover business, economics, markets, finance, technology, science, design, and fashion.',
+			title: 'Quartz',
+		}}
+		name="Small with no badge"
+		size="large"
+	>
+		{args => (
+			<div style={{ maxWidth: 400 }}>
+				<BadgeGroup {...args} />
+			</div>
+		)}
+	</Story>
+</Canvas>
+
+### Large with wrapping tagline
 
 <Canvas>
 	<Story
 		args={{
 			imageUrl: 'https://cms.qz.com/wp-content/uploads/2019/12/fintech_guide_cover.jpg?quality=75&strip=all&w=100&h=100&crop=1',
 			kicker: 'From our Guide',
+			size: 'large',
 			tagline: 'Which unicorns will fade and which are here to stay. A guide to the biggest beasts in the fintech unicorn herd.',
 			title: 'Beyond the fintech hype',
 		}}
-		name="Wrapping tagline"
+		name="Large with wrapping tagline"
 	>
 		{args => (
 			<div style={{ maxWidth: 400 }}>

--- a/src/components/BadgeGroup/BadgeGroup.stories.mdx
+++ b/src/components/BadgeGroup/BadgeGroup.stories.mdx
@@ -72,14 +72,14 @@ A `BadgeGroup` is a <LinkTo kind="TextGroup">TextGroup</LinkTo> accompanied by a
 	</Story>
 </Canvas>
 
-### Large with wrapping tagline
+### Medium with wrapping tagline
 
 <Canvas>
 	<Story
 		args={{
 			imageUrl: 'https://cms.qz.com/wp-content/uploads/2019/12/fintech_guide_cover.jpg?quality=75&strip=all&w=100&h=100&crop=1',
 			kicker: 'From our Guide',
-			size: 'large',
+			size: 'medium',
 			tagline: 'Which unicorns will fade and which are here to stay. A guide to the biggest beasts in the fintech unicorn herd.',
 			title: 'Beyond the fintech hype',
 		}}

--- a/src/components/BadgeGroup/BadgeGroup.stories.mdx
+++ b/src/components/BadgeGroup/BadgeGroup.stories.mdx
@@ -43,7 +43,7 @@ A `BadgeGroup` is a <LinkTo kind="TextGroup">TextGroup</LinkTo> accompanied by a
 			title: 'The New Normal',
 		}}
 		name="Small"
-		size="large"
+		size="small"
 	>
 		{args => (
 			<div style={{ maxWidth: 400 }}>
@@ -62,7 +62,7 @@ A `BadgeGroup` is a <LinkTo kind="TextGroup">TextGroup</LinkTo> accompanied by a
 			title: 'Quartz',
 		}}
 		name="Small with no badge"
-		size="large"
+		size="small"
 	>
 		{args => (
 			<div style={{ maxWidth: 400 }}>

--- a/src/components/Hed/Hed.docs.mdx
+++ b/src/components/Hed/Hed.docs.mdx
@@ -17,6 +17,12 @@ A hed (short for headline) is the title of a story or unit of content. This comp
   <Story id="hed--small" />
 </Preview>
 
+### Medium
+
+<Preview>
+  <Story id="hed--medium" />
+</Preview>
+
 ### Large
 
 <Preview>

--- a/src/components/Hed/Hed.jsx
+++ b/src/components/Hed/Hed.jsx
@@ -22,7 +22,7 @@ Hed.propTypes = {
 	/**
 	 * The size of the headline.
 	 */
-	size: PropTypes.oneOf( [ 'large', 'small' ] ).isRequired,
+	size: PropTypes.oneOf( [ 'small', 'medium', 'large' ] ).isRequired,
 };
 
 Hed.defaultProps = {

--- a/src/components/Hed/Hed.scss
+++ b/src/components/Hed/Hed.scss
@@ -7,6 +7,10 @@
 }
 
 .small {
+	@include font-maison-800-2;
+}
+
+.medium {
 	@include font-maison-800-4;
 }
 

--- a/src/components/Hed/Hed.story.jsx
+++ b/src/components/Hed/Hed.story.jsx
@@ -14,6 +14,10 @@ export const Small = () => (
 	<Hed size="small">All the “wellness” products Americans love to buy are sold on both Infowars and Goop</Hed>
 );
 
+export const Medium = () => (
+	<Hed size="medium">All the “wellness” products Americans love to buy are sold on both Infowars and Goop</Hed>
+);
+
 export const Large = () => (
 	<Hed size="large">All the “wellness” products Americans love to buy are sold on both Infowars and Goop</Hed>
 );

--- a/src/components/TextGroup/TextGroup.docs.mdx
+++ b/src/components/TextGroup/TextGroup.docs.mdx
@@ -24,6 +24,24 @@ import { TextGroup } from '@quartz/interface/src/components';
 
 ## Examples
 
+### Small
+
+<Preview>
+  <Story id="textgroup--small" />
+</Preview>
+
+### Medium
+
+<Preview>
+  <Story id="textgroup--medium" />
+</Preview>
+
+### Large
+
+<Preview>
+  <Story id="textgroup--large" />
+</Preview>
+
 ### A taxonomy
 
 <Preview>

--- a/src/components/TextGroup/TextGroup.jsx
+++ b/src/components/TextGroup/TextGroup.jsx
@@ -8,6 +8,7 @@ import styles from './TextGroup.scss';
 function TextGroup ( {
 	isArticle,
 	kicker,
+	size,
 	tagline,
 	title,
 } ) {
@@ -16,14 +17,14 @@ function TextGroup ( {
 			{
 				kicker &&
 					<Kicker>
-						<div className={`${styles.kicker} ${isArticle ? styles.isArticle : ''}`}>{kicker}</div>
+						<div className={`${styles.kicker} ${styles[ size ]} ${isArticle ? styles.isArticle : ''}`}>{kicker}</div>
 					</Kicker>
 			}
-			<Hed size="small">{title}</Hed>
+			<Hed size={size}>{title}</Hed>
 			{
 				tagline &&
 					<Tagline>
-						<div className={styles.tagline}>{tagline}</div>
+						<div className={`${styles.tagline} ${styles[ size ]}`}>{tagline}</div>
 					</Tagline>
 			}
 		</>
@@ -44,6 +45,12 @@ TextGroup.propTypes = {
 	kicker: PropTypes.node,
 
 	/**
+	 * Size preset for the text group. Adjusts the font size and spacing
+	 * of the headline (Hed component).
+	 */
+	size: PropTypes.oneOf( [ 'small', 'medium', 'large' ] ),
+
+	/**
 	 * Tagline to appear beneath the title.
 	 */
 	tagline: PropTypes.string,
@@ -56,6 +63,7 @@ TextGroup.propTypes = {
 
 TextGroup.defaultProps = {
 	isArticle: false,
+	size: 'medium',
 };
 
 export default TextGroup;

--- a/src/components/TextGroup/TextGroup.scss
+++ b/src/components/TextGroup/TextGroup.scss
@@ -1,4 +1,5 @@
 @import '~@quartz/styles/scss/color-scheme';
+@import '~@quartz/styles/scss/media-queries';
 
 .kicker {
 	color: $color-typography-faint;
@@ -7,8 +8,20 @@
 	&.is-article {
 		color: $color-accent;
 	}
+
+	&.large {
+		@include for-tablet-landscape-up {
+			margin-bottom: 8px;
+		}
+	}
 }
 
 .tagline {
 	margin-top: 4px;
+
+	&.large {
+		@include for-tablet-landscape-up {
+			margin-top: 8px;
+		}
+	}
 }

--- a/src/components/TextGroup/TextGroup.story.jsx
+++ b/src/components/TextGroup/TextGroup.story.jsx
@@ -10,6 +10,36 @@ export default {
 	},
 };
 
+export const Small = () => (
+	<div style={{ maxWidth: 400 }}>
+		<TextGroup
+			size="small"
+			tagline="The concise, conversational rundown you need to start your day."
+			title="Quartz Daily Brief"
+		/>
+	</div>
+);
+
+export const Medium = () => (
+	<div style={{ maxWidth: 400 }}>
+		<TextGroup
+			size="medium"
+			tagline="The concise, conversational rundown you need to start your day."
+			title="Quartz Daily Brief"
+		/>
+	</div>
+);
+
+export const Large = () => (
+	<div style={{ maxWidth: 600 }}>
+		<TextGroup
+			size="large"
+			tagline="The concise, conversational rundown you need to start your day."
+			title="Quartz Daily Brief"
+		/>
+	</div>
+);
+
 export const Taxonomy = () => (
 	<div style={{ maxWidth: 400 }}>
 		<TextGroup
@@ -21,10 +51,11 @@ export const Taxonomy = () => (
 );
 
 export const Article = () => (
-	<div style={{ maxWidth: 400 }}>
+	<div style={{ maxWidth: 600 }}>
 		<TextGroup
 			isArticle={true}
 			kicker="Lightning Goals"
+			size="large"
 			tagline="Oct. 12, 2018 • Quartz"
 			title="Usain Bolt is slowly but surely becoming a soccer player"
 		/>


### PR DESCRIPTION
I spoke with Daniel and confirmed that there are three possible sizes of text groups: small, medium and large. Each size corresponds to a different size of Hed.

This PR adds a `size` prop to the TextGroup component with a default of medium. It also adds a size value to the Hed component.

