### PR TITLE
TabNav and TabNavItem

### DIFF
--- a/src/components/PageHeader/PageHeader.stories.mdx
+++ b/src/components/PageHeader/PageHeader.stories.mdx
@@ -1,5 +1,6 @@
 import { Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import PageHeader from './PageHeader.jsx';
+import { TabNav, TabNavItem } from '../TabNav/TabNav';
 
 <Meta title="PageHeader" component={PageHeader} />
 
@@ -13,7 +14,7 @@ It takes optional children, which should be navigation elements (tabs, search ba
 
 <ArgsTable story="Default" />
 
-## Usage Guidelines
+## Usage guidelines
 
 - **Do not** use this on a page where an H1 already exists
 - **Do not** use the optional children for general page content
@@ -33,7 +34,7 @@ It takes optional children, which should be navigation elements (tabs, search ba
 	</Story>
 </Canvas>
 
-### With Intro, No Border
+### With intro, no border
 
 <Canvas>
 	<Story
@@ -48,27 +49,19 @@ It takes optional children, which should be navigation elements (tabs, search ba
 	</Story>
 </Canvas>
 
-### With Children
+### With nested navigation
 
 <Canvas>
 	<Story
 		args={{
 			title: "Good morning, USA",
 			children: (
-				<form>
-					<input
-						style={{
-							width: '200px',
-							margin: '15px',
-							border: '1px solid #ccc',
-							borderRadius: '8px',
-							padding: '5px 8px',
-							fontSize: '16px',
-						}}
-						placeholder="Search Quartz"
-						aria-label="Search"
-					/>
-				</form>
+				<TabNav>
+					<TabNavItem isActive={true}>Stan</TabNavItem>
+					<TabNavItem>Francine</TabNavItem>
+					<TabNavItem>Roger</TabNavItem>
+					<TabNavItem>Klaus</TabNavItem>
+				</TabNav>
 			),
 		}}
 		name="With Children"

--- a/src/components/TabNav/TabNav.jsx
+++ b/src/components/TabNav/TabNav.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styles from './TabNav.scss';
+
+const TabNav = ( { children } ) => (
+	<nav className={styles.container}>
+		<div className={styles[ 'scroll-container' ]}>
+			<ul className={styles.tablist}>
+				{children}
+			</ul>
+		</div>
+	</nav>
+);
+
+TabNav.propTypes = {
+	/**
+	 * Child node to be rendered as the inner HTML of the component.
+	 */
+	children: PropTypes.node,
+};
+
+const TabNavItem = ( { children, isActive } ) => <li aria-current={isActive} className={styles.tab}>{children}</li>;
+
+TabNavItem.propTypes = {
+	/**
+	 * Child node to be rendered as the inner HTML of the component.
+	 */
+	children: PropTypes.node.isRequired,
+	/**
+	 * Whether this is the currently active tab. Applies
+	 * `aria-current="true"`. Only one tab may be active at a time.
+	 */
+	isActive: PropTypes.bool.isRequired,
+};
+
+TabNavItem.defaultProps = {
+	isActive: false,
+};
+
+export { TabNav, TabNavItem };

--- a/src/components/TabNav/TabNav.scss
+++ b/src/components/TabNav/TabNav.scss
@@ -1,0 +1,70 @@
+@import '~@quartz/styles/scss/color-scheme';
+@import '~@quartz/styles/scss/fonts';
+@import '~@quartz/styles/scss/media-queries';
+@import '~@quartz/styles/scss/helpers/resets';
+@import '~@quartz/styles/scss/tokens';
+
+.container {
+	text-align: center;
+	white-space: nowrap;
+	position: relative;
+	width: 100%;
+
+	&::after {
+		content: '';
+		position: absolute;
+		right: 0;
+		top: 0;
+		width: 15%;
+		height: 100%;
+		background: linear-gradient(to right, $color-background-1-transparent, $color-background-1);
+		pointer-events: none;
+	}
+}
+
+.scroll-container {
+	overflow: auto;
+}
+
+.tablist {
+	@include reset-ul;
+
+	display: inline-flex;
+}
+
+.tab {
+	@include font-maison-extended-700-1;
+
+	margin: 0 12px;
+	padding: 16px 0 14px;
+	color: $color-typography-faint;
+
+	&:first-child {
+		margin-left: $size-gutter-mobile;
+
+		@include for-tablet-portrait-up {
+			margin-left: $size-gutter-tablet;
+		}
+
+		@include for-desktop-up {
+			margin-left: $size-gutter-desktop;
+		}
+	}
+
+	&:last-child {
+		margin-right: $size-gutter-mobile;
+
+		@include for-tablet-portrait-up {
+			margin-right: $size-gutter-tablet;
+		}
+
+		@include for-desktop-up {
+			margin-right: $size-gutter-desktop;
+		}
+	}
+
+	&[aria-current="true"] {
+		border-bottom: 2px solid $color-accent;
+		color: $color-accent;
+	}
+}

--- a/src/components/TabNav/TabNav.stories.mdx
+++ b/src/components/TabNav/TabNav.stories.mdx
@@ -1,27 +1,22 @@
 import { ArgsTable, Canvas, Props, Story } from '@storybook/addon-docs/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import { TabNav, TabNavItem } from './TabNav';
 
 <Meta title="TabNav" component={TabNav} />
 
 # TabNav and TabNavItem
 
-Navigational components for linking to sibling pages. Use `TabNav` for the container element and `TabNavItem` for individual navigational items.
+Navigational components for linking to sibling pages. Use TabNav for the container element and TabNavItem for individual navigational items.
 
-A link (`<a>`) or button (`<button>`) element should be passed into each `TabNavItem` as a child node.
-
-## Usage
-
-```js
-import { TabNav, TabNavItem } from '@quartz/interface/src/components';
-```
+A link (`<a>`) or button (`<button>`) element should be passed into each TabNavItem as a child node.
 
 ## Usage guidelines
 
-- **Do** use `TabNav` to present sibling pages.
-- **Do** use `TabNav` inside the `Header` component when possible.
-- **Do not** use the `TabNavItem` component without an immediate `TabNav` parent.
-- **Do not** apply `isActive={true}` to more than one `TabNavItem` at a time.
-- **Do not** use a `TabNav` to link to pages that are not semantically related.
+- **Do** use TabNav to present sibling pages.
+- **Do** use TabNav inside the <LinkTo kind="PageHeader">PageHeader</LinkTo> component when possible.
+- **Do not** use the TabNavItem component without an immediate TabNav parent.
+- **Do not** apply `isActive={true}` to more than one TabNavItem at a time.
+- **Do not** use a TabNav to link to pages that are not semantically related.
 
 ## Props
 

--- a/src/components/TabNav/TabNav.stories.mdx
+++ b/src/components/TabNav/TabNav.stories.mdx
@@ -5,7 +5,7 @@ import { TabNav, TabNavItem } from './TabNav';
 
 # TabNav and TabNavItem
 
-Navigational components for linking to sibling pages. Includes `TabNav` for the container element and `TabNavItem` for individual navigational items.
+Navigational components for linking to sibling pages. Use `TabNav` for the container element and `TabNavItem` for individual navigational items.
 
 A link (`<a>`) or button (`<button>`) element should be passed into each `TabNavItem` as a child node.
 

--- a/src/components/TabNav/TabNav.stories.mdx
+++ b/src/components/TabNav/TabNav.stories.mdx
@@ -1,0 +1,59 @@
+import { ArgsTable, Canvas, Props, Story } from '@storybook/addon-docs/blocks';
+import { TabNav, TabNavItem } from './TabNav';
+
+<Meta title="TabNav" component={TabNav} />
+
+# TabNav and TabNavItem
+
+Navigational components for linking to sibling pages. Includes `TabNav` for the container element and `TabNavItem` for individual navigational items.
+
+A link (`<a>`) or button (`<button>`) element should be passed into each `TabNavItem` as a child node.
+
+## Usage
+
+```js
+import { TabNav, TabNavItem } from '@quartz/interface/src/components';
+```
+
+## Usage guidelines
+
+- **Do** use `TabNav` to present sibling pages.
+- **Do** use `TabNav` inside the `Header` component.
+- **Do** use `TabNav` inside the `Header` component.
+- **Do not** use `TabNavItem` components without an immediate `TabNav` parent.
+- **Do not** apply `isActive={true}` to more than one `TabNavItem` at a time.
+- **Do not** use a `TabNav` to link to pages that are not semantically related.
+
+## Props
+
+<Props of={TabNav} />
+
+### TabNavItem
+
+<Props of={TabNavItem} />
+
+## Examples
+
+### Default
+
+<Canvas>
+	<Story name="Default">
+		{args => (
+			<TabNav>
+				<TabNavItem isActive={true}>
+					<a style={{color: 'inherit'}} href="#">John</a>
+				</TabNavItem>
+				<TabNavItem>
+					<a style={{color: 'inherit'}} href="#">Paul</a>
+				</TabNavItem>
+				<TabNavItem>
+					<a style={{color: 'inherit'}} href="#">George</a>
+				</TabNavItem>
+				<TabNavItem>
+					<a style={{color: 'inherit'}} href="#">Ringo</a>
+				</TabNavItem>
+			</TabNav>
+		)}
+	</Story>
+</Canvas>
+

--- a/src/components/TabNav/TabNav.stories.mdx
+++ b/src/components/TabNav/TabNav.stories.mdx
@@ -18,13 +18,14 @@ import { TabNav, TabNavItem } from '@quartz/interface/src/components';
 ## Usage guidelines
 
 - **Do** use `TabNav` to present sibling pages.
-- **Do** use `TabNav` inside the `Header` component.
-- **Do** use `TabNav` inside the `Header` component.
-- **Do not** use `TabNavItem` components without an immediate `TabNav` parent.
+- **Do** use `TabNav` inside the `Header` component when possible.
+- **Do not** use the `TabNavItem` component without an immediate `TabNav` parent.
 - **Do not** apply `isActive={true}` to more than one `TabNavItem` at a time.
 - **Do not** use a `TabNav` to link to pages that are not semantically related.
 
 ## Props
+
+### TabNav
 
 <Props of={TabNav} />
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -6,4 +6,5 @@ export { default as Checkbox } from './Checkbox/Checkbox';
 export { default as Image } from './Image/Image';
 export { default as RadioButton } from './RadioButton/RadioButton';
 export { default as Spinner } from './Spinner/Spinner';
+export { TabNav, TabNavItem } from './TabNav/TabNav';
 export { default as TextGroup } from './TextGroup/TextGroup';


### PR DESCRIPTION
Adds the `TabNav` and `TabNavItem` components (FKA TabNavigation). This component requires a little more work on the part of the consumer than its qz-react counterpart - it is now the responsibility of the consumer to build their own component tree (TabNav ->  TabNavItem -> a) rather than passing in an array of objects for the nav items.
