### PR TITLE
Add ColorScheme and theming to Prism

### DIFF
--- a/.storybook/addons/MockAppDecorator/MockAppDecorator.jsx
+++ b/.storybook/addons/MockAppDecorator/MockAppDecorator.jsx
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types';
 import '!style-loader!css-loader!sass-loader!./MockAppDecorator.scss';
 
 /**
- * A decorator component that provides baseline conditions required to display
- * library components. All story components are automatically wrapped (see
- * .storybook/preview.js).
+ * A decorator that provides baseline conditions required to render stories. All
+ * stories are automatically wrapped (see .storybook/preview.js).
  *
  * https://storybook.js.org/docs/react/writing-stories/decorators
  */

--- a/.storybook/addons/MockAppDecorator/MockAppDecorator.jsx
+++ b/.storybook/addons/MockAppDecorator/MockAppDecorator.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import '!style-loader!css-loader!sass-loader!./MockAppDecorator.scss';
 
-/*
-	A decorator component that provides baseline conditions required to
-	display library components. All story components are automatically
-	wrapped (see .storybook/preview.js)
-
-	https://storybook.js.org/docs/addons/introduction/#1-decorators
-*/
+/**
+ * A decorator component that provides baseline conditions required to display
+ * library components. All story components are automatically wrapped (see
+ * .storybook/preview.js).
+ *
+ * https://storybook.js.org/docs/react/writing-stories/decorators
+ */
 const MockAppDecorator = ( { children } ) => (
 	<main className="fonts-loaded">{children}</main>
 );

--- a/.storybook/addons/StoryTheme/StoryTheme.jsx
+++ b/.storybook/addons/StoryTheme/StoryTheme.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ColorScheme, { schemes } from '../../../src/components/ColorScheme/ColorScheme';
 
-/*
- * Decorator to supply a ColorScheme corresponding to the user's theme
- * selection. All story components are automatically wrapped.
+/**
+ * Decorator that supplies a ColorScheme corresponding to the user's theme
+ * selection. All stories are automatically wrapped.
  *
  * https://github.com/tonai/storybook-addon-themes#custom-decorator
  */

--- a/.storybook/addons/StoryTheme/StoryTheme.jsx
+++ b/.storybook/addons/StoryTheme/StoryTheme.jsx
@@ -3,12 +3,11 @@ import PropTypes from 'prop-types';
 import ColorScheme, { schemes } from '../../../src/components/ColorScheme/ColorScheme';
 
 /*
-	A decorator component that provides baseline conditions required to
-	display library components. All story components are automatically
-	wrapped (see .storybook/preview.js)
-
-	https://storybook.js.org/docs/addons/introduction/#1-decorators
-*/
+ * Decorator to supply a ColorScheme corresponding to the user's theme
+ * selection. All story components are automatically wrapped.
+ *
+ * https://github.com/tonai/storybook-addon-themes#custom-decorator
+ */
 function StoryTheme ( { children, themeName } ) {
 	let scheme = schemes.LIGHT;
 
@@ -37,7 +36,7 @@ function StoryTheme ( { children, themeName } ) {
 
 StoryTheme.propTypes = {
 	children: PropTypes.node,
-	themeName: PropTypes.string.isRequired,
+	themeName: PropTypes.oneOf( [ 'At Work Dark', 'At Work Light', 'Dark', 'Light' ] ).isRequired,
 };
 
 export default StoryTheme;

--- a/.storybook/addons/StoryTheme/StoryTheme.jsx
+++ b/.storybook/addons/StoryTheme/StoryTheme.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ColorScheme, { schemes } from '../../../src/components/ColorScheme/ColorScheme';
+
+/*
+	A decorator component that provides baseline conditions required to
+	display library components. All story components are automatically
+	wrapped (see .storybook/preview.js)
+
+	https://storybook.js.org/docs/addons/introduction/#1-decorators
+*/
+function StoryTheme ( { children, themeName } ) {
+	let scheme = schemes.LIGHT;
+
+	if ( 'Dark' === themeName ) {
+		scheme = schemes.DARK;
+	}
+
+	if ( 'At Work Light' === themeName ) {
+		scheme = schemes.WORK_LIGHT;
+	}
+
+	if ( 'At Work Dark' === themeName ) {
+		scheme = schemes.WORK_DARK;
+	}
+
+	return (
+		<>
+			<ColorScheme
+				{...scheme}
+				type="default"
+			/>
+			{children}
+		</>
+	);
+}
+
+StoryTheme.propTypes = {
+	children: PropTypes.node,
+	themeName: PropTypes.string.isRequired,
+};
+
+export default StoryTheme;

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -17,6 +17,7 @@ module.exports = {
 				backgrounds: false, // Disable in favor of own theming (TODO).
 			},
 		},
+		'storybook-addon-themes',
 	],
 	webpackFinal: async config => {
 		// Add support for .scss files (Sass)

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,12 +1,26 @@
 import React from 'react';
 import { addDecorator, addParameters } from '@storybook/react';
-import MockAppDecorator from './addons/MockAppDecorator/MockAppDecorator'
-import qzTheme from './themes/qz';
+import { withThemes } from 'storybook-addon-themes/react';
+import { color } from '@quartz/styles/dictionaries/colors.json';
+import MockAppDecorator from './addons/MockAppDecorator/MockAppDecorator';
+import StoryTheme from './addons/StoryTheme/StoryTheme';
+import theme from './themes/qz';
 
+addDecorator( withThemes );
 addDecorator( Story => <MockAppDecorator><Story /></MockAppDecorator> );
 
 addParameters( {
 	options: {
-		theme: qzTheme,
+		theme, // This theme controls Storybook itself.
+	},
+	// These themes are applied to Stories (inside the iframe).
+	themes: {
+		Decorator: StoryTheme,
+		list: [
+			{ name: 'Light', color: color[ 'off-white' ].value, default: true },
+			{ name: 'Dark', color: color[ 'dark-blue' ].value },
+			{ name: 'At Work Light', color: color[ 'light-teal' ].value },
+			{ name: 'At Work Dark', color: color[ 'dark-teal' ].value },
+		],
 	},
 } );

--- a/.storybook/themes/qz.js
+++ b/.storybook/themes/qz.js
@@ -2,7 +2,7 @@ import { create } from '@storybook/theming/create';
 
 export default create( {
 	base: 'light',
-	brandTitle: 'Quartz Prism UI',
+	brandTitle: '🌈 Prism UI',
 	brandUrl: 'https://prism.qz.com',
 	fontBase: '"MaisonNeue", "Helvetica Neue", Helvetica, sans-serif',
 } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -4903,8 +4903,8 @@
       }
     },
     "@quartz/js-utils": {
-      "version": "github:Quartz/js-utils#8ab4cf941f0c0856dac9ee1da43c9cbb375b9ccd",
-      "from": "github:Quartz/js-utils#8ab4cf9"
+      "version": "github:Quartz/js-utils#f7a4ea18589bf1f158d2a2c4edfa191ce4daa131",
+      "from": "github:Quartz/js-utils#f7a4ea1"
     },
     "@quartz/stylelint-config": {
       "version": "1.0.0",
@@ -6598,6 +6598,15 @@
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz",
       "integrity": "sha512-9GfTo3a0PHwQeTVoqs0g5bS28KkSY48pp5659wA+Dp4MqceDEa8EHBqrllJvvtyusszyJhViUEap0FDvlk/9Zg==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-textarea-autosize": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react-textarea-autosize/-/react-textarea-autosize-4.3.5.tgz",
+      "integrity": "sha512-PiDL83kPMTolyZAWW3lyzO6ktooTb9tFTntVy7CA83/qFLWKLJ5bLeRboy6J6j3b1e8h2Eec6gBTEOOJRjV14A==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -8961,6 +8970,12 @@
         }
       }
     },
+    "can-use-dom": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
+      "integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo=",
+      "dev": true
+    },
     "caniuse-lite": {
       "version": "1.0.30001096",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001096.tgz",
@@ -10143,6 +10158,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true
+    },
+    "detect-node-es": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.0.0.tgz",
+      "integrity": "sha512-S4AHriUkTX9FoFvL4G8hXDcx6t3gp2HpfCza3Q0v6S78gul2hKWifLQbeW+ZF89+hSm2ZIc/uF3J97ZgytgTRg==",
       "dev": true
     },
     "detect-port": {
@@ -12333,6 +12354,12 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
+    },
+    "focus-lock": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.7.0.tgz",
+      "integrity": "sha512-LI7v2mH02R55SekHYdv9pRHR9RajVNyIJ2N5IEkWbg7FT5ZmJ9Hw4mWxHeEUcd+dJo0QmzztHvDvWcc7prVFsw==",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -17504,6 +17531,12 @@
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
     "lodash.escape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
@@ -17522,10 +17555,22 @@
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
       "dev": true
     },
     "lodash.uniq": {
@@ -20296,6 +20341,15 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-clientside-effect": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz",
+      "integrity": "sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0"
+      }
+    },
     "react-color": {
       "version": "2.18.1",
       "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.18.1.tgz",
@@ -20817,6 +20871,20 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
       "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==",
       "dev": true
+    },
+    "react-focus-lock": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.4.1.tgz",
+      "integrity": "sha512-c5ZP56KSpj9EAxzScTqQO7bQQNPltf/W1ZEBDqNDOV1XOIwvAyHX0O7db9ekiAtxyKgnqZjQlLppVg94fUeL9w==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^0.7.0",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.2",
+        "use-callback-ref": "^1.2.1",
+        "use-sidecar": "^1.0.1"
+      }
     },
     "react-helmet-async": {
       "version": "1.0.6",
@@ -21705,6 +21773,12 @@
         }
       }
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -22387,6 +22461,12 @@
         }
       }
     },
+    "shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
+      "dev": true
+    },
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
@@ -22455,6 +22535,30 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "simplebar": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.2.3.tgz",
+      "integrity": "sha512-9no0pK7/1y+8/oTF3sy/+kx0PjQ3uk4cYwld5F1CJGk2gx+prRyUq8GRfvcVLq5niYWSozZdX73a2wIr1o9l/g==",
+      "dev": true,
+      "requires": {
+        "can-use-dom": "^0.1.0",
+        "core-js": "^3.0.1",
+        "lodash.debounce": "^4.0.8",
+        "lodash.memoize": "^4.1.2",
+        "lodash.throttle": "^4.1.1",
+        "resize-observer-polyfill": "^1.5.1"
+      }
+    },
+    "simplebar-react": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.2.3.tgz",
+      "integrity": "sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==",
+      "dev": true,
+      "requires": {
+        "prop-types": "^15.6.1",
+        "simplebar": "^4.2.3"
+      }
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -22798,6 +22902,298 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.12.0.tgz",
       "integrity": "sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw==",
       "dev": true
+    },
+    "storybook-addon-themes": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/storybook-addon-themes/-/storybook-addon-themes-5.4.1.tgz",
+      "integrity": "sha512-pSMiaXxe022Aq9pa2Xx97N0d49ihpgo6+dzlZOj9Vtz3ygoN5M8arnNSppp430lbhpOKfGSK3p8WPNMkfNBnWQ==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "^5.3.14",
+        "@storybook/client-logger": "^5.3.14",
+        "@storybook/components": "^5.3.14",
+        "@storybook/core-events": "^5.3.14",
+        "@storybook/theming": "^5.3.14",
+        "core-js": "^2.6.5",
+        "global": "^4.3.2",
+        "memoizerific": "^1.11.3",
+        "util-deprecate": "^1.0.2"
+      },
+      "dependencies": {
+        "@storybook/addons": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.19.tgz",
+          "integrity": "sha512-Ky/k22p6i6FVNvs1VhuFyGvYJdcp+FgXqFgnPyY/OXJW/vPDapdElpTpHJZLFI9I2FQBDcygBPU5RXkumQ+KUQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "5.3.19",
+            "@storybook/channels": "5.3.19",
+            "@storybook/client-logger": "5.3.19",
+            "@storybook/core-events": "5.3.19",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "util-deprecate": "^1.0.2"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "3.6.5",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+              "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+              "dev": true
+            }
+          }
+        },
+        "@storybook/api": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.19.tgz",
+          "integrity": "sha512-U/VzDvhNCPmw2igvJYNNM+uwJCL+3teiL6JmuoL4/cmcqhI6IqqG9dZmMP1egoCd19wXEP7rnAfB/VcYVg41dQ==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.2.1",
+            "@storybook/channels": "5.3.19",
+            "@storybook/client-logger": "5.3.19",
+            "@storybook/core-events": "5.3.19",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "5.3.19",
+            "@storybook/theming": "5.3.19",
+            "@types/reach__router": "^1.2.3",
+            "core-js": "^3.0.1",
+            "fast-deep-equal": "^2.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "prop-types": "^15.6.2",
+            "react": "^16.8.3",
+            "semver": "^6.0.0",
+            "shallow-equal": "^1.1.0",
+            "store2": "^2.7.1",
+            "telejson": "^3.2.0",
+            "util-deprecate": "^1.0.2"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "3.6.5",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+              "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+              "dev": true
+            }
+          }
+        },
+        "@storybook/channels": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.19.tgz",
+          "integrity": "sha512-38seaeyshRGotTEZJppyYMg/Vx2zRKgFv1L6uGqkJT0LYoNSYtJhsiNFCJ2/KUJu2chAJ/j8h80bpVBVLQ/+WA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "3.6.5",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+              "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+              "dev": true
+            }
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.19.tgz",
+          "integrity": "sha512-nHftT9Ow71YgAd2/tsu79kwKk30mPuE0sGRRUHZVyCRciGFQweKNOS/6xi2Aq+WwBNNjPKNlbgxwRt1yKe1Vkg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "3.6.5",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+              "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+              "dev": true
+            }
+          }
+        },
+        "@storybook/components": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.3.19.tgz",
+          "integrity": "sha512-3g23/+ktlocaHLJKISu9Neu3XKa6aYP2ctDYkRtGchSB0Q55hQsUVGO+BEVuT7Pk2D59mVCxboBjxcRoPUY4pw==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "5.3.19",
+            "@storybook/theming": "5.3.19",
+            "@types/react-syntax-highlighter": "11.0.4",
+            "@types/react-textarea-autosize": "^4.3.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "markdown-to-jsx": "^6.11.4",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "popper.js": "^1.14.7",
+            "prop-types": "^15.7.2",
+            "react": "^16.8.3",
+            "react-dom": "^16.8.3",
+            "react-focus-lock": "^2.1.0",
+            "react-helmet-async": "^1.0.2",
+            "react-popper-tooltip": "^2.8.3",
+            "react-syntax-highlighter": "^11.0.2",
+            "react-textarea-autosize": "^7.1.0",
+            "simplebar-react": "^1.0.0-alpha.6",
+            "ts-dedent": "^1.1.0"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "3.6.5",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+              "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+              "dev": true
+            }
+          }
+        },
+        "@storybook/core-events": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.19.tgz",
+          "integrity": "sha512-lh78ySqMS7pDdMJAQAe35d1I/I4yPTqp09Cq0YIYOxx9BQZhah4DZTV1QIZt22H5p2lPb5MWLkWSxBaexZnz8A==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "3.6.5",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+              "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+              "dev": true
+            }
+          }
+        },
+        "@storybook/router": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.19.tgz",
+          "integrity": "sha512-yNClpuP7BXQlBTRf6Ggle3/R349/k6kvI5Aim4jf6X/2cFVg2pzBXDAF41imNm9PcvdxwabQLm6I48p7OvKr/w==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.2.1",
+            "@storybook/csf": "0.0.1",
+            "@types/reach__router": "^1.2.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.6.0",
+            "util-deprecate": "^1.0.2"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "3.6.5",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+              "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+              "dev": true
+            }
+          }
+        },
+        "@storybook/theming": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.19.tgz",
+          "integrity": "sha512-ecG+Rq3hc1GOzKHamYnD4wZ0PEP9nNg0mXbC3RhbxfHj+pMMCWWmx9B2Uu75SL1PTT8WcfkFO0hU/0IO84Pzlg==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.0.20",
+            "@emotion/styled": "^10.0.17",
+            "@storybook/client-logger": "5.3.19",
+            "core-js": "^3.0.1",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.19",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "prop-types": "^15.7.2",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^1.1.0"
+          },
+          "dependencies": {
+            "core-js": {
+              "version": "3.6.5",
+              "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+              "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+              "dev": true
+            }
+          }
+        },
+        "core-js": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
+        "highlight.js": {
+          "version": "9.13.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
+          "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
+          "dev": true
+        },
+        "lowlight": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.11.0.tgz",
+          "integrity": "sha512-xrGGN6XLL7MbTMdPD6NfWPwY43SNkjf/d0mecSx/CW36fUZTjRHEq0/Cdug3TWKtRXLWi7iMl1eP0olYxj/a4A==",
+          "dev": true,
+          "requires": {
+            "fault": "^1.0.2",
+            "highlight.js": "~9.13.0"
+          }
+        },
+        "react-syntax-highlighter": {
+          "version": "11.0.2",
+          "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-11.0.2.tgz",
+          "integrity": "sha512-kqmpM2OH5OodInbEADKARwccwSQWBfZi0970l5Jhp4h39q9Q65C4frNcnd6uHE5pR00W8pOWj9HDRntj2G4Rww==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "highlight.js": "~9.13.0",
+            "lowlight": "~1.11.0",
+            "prismjs": "^1.8.4",
+            "refractor": "^2.4.1"
+          }
+        },
+        "react-textarea-autosize": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-7.1.2.tgz",
+          "integrity": "sha512-uH3ORCsCa3C6LHxExExhF4jHoXYCQwE5oECmrRsunlspaDAbS4mGKNlWZqjLfInWtFQcf0o1n1jC/NGXFdUBCg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "prop-types": "^15.6.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "telejson": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/telejson/-/telejson-3.3.0.tgz",
+          "integrity": "sha512-er08AylQ+LEbDLp1GRezORZu5wKOHaBczF6oYJtgC3Idv10qZ8A3p6ffT+J5BzDKkV9MqBvu8HAKiIIOp6KJ2w==",
+          "dev": true,
+          "requires": {
+            "@types/is-function": "^1.0.0",
+            "global": "^4.4.0",
+            "is-function": "^1.0.1",
+            "is-regex": "^1.0.4",
+            "is-symbol": "^1.0.3",
+            "isobject": "^4.0.0",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3"
+          }
+        }
+      }
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -25292,6 +25688,12 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "use-callback-ref": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.4.tgz",
+      "integrity": "sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ==",
+      "dev": true
+    },
     "use-composed-ref": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.0.0.tgz",
@@ -25314,6 +25716,16 @@
       "dev": true,
       "requires": {
         "use-isomorphic-layout-effect": "^1.0.0"
+      }
+    },
+    "use-sidecar": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.0.3.tgz",
+      "integrity": "sha512-ygJwGUBeQfWgDls7uTrlEDzJUUR67L8Rm14v/KfFtYCdHhtjHZx1Krb3DIQl3/Q5dJGfXLEQ02RY8BdNBv87SQ==",
+      "dev": true,
+      "requires": {
+        "detect-node-es": "^1.0.0",
+        "tslib": "^1.9.3"
       }
     },
     "util": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"src/**/*.scss"
 	],
 	"dependencies": {
-		"@quartz/js-utils": "github:Quartz/js-utils#8ab4cf9"
+		"@quartz/js-utils": "github:Quartz/js-utils#f7a4ea1"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.10.4",
@@ -49,6 +49,7 @@
 		"react": "^16.13.1",
 		"react-dom": "^16.13.1",
 		"sass-loader": "^9.0.2",
+		"storybook-addon-themes": "^5.4.1",
 		"style-loader": "^1.2.1",
 		"stylelint": "^13.6.1"
 	}

--- a/src/components/ColorScheme/ColorScheme.jsx
+++ b/src/components/ColorScheme/ColorScheme.jsx
@@ -1,0 +1,261 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+	hexToRgb,
+	minifyCss,
+} from '@quartz/js-utils';
+import { color } from '@quartz/styles/dictionaries/colors.json';
+
+// Reshape the color dictionary JSON for easier application
+const colors = Object.keys( color ).reduce( ( acc, colorName ) => ( {
+	...acc,
+	[ colorName ]: color[ colorName ].value,
+} ), {} );
+
+/**
+ * Export some color schemes so that pages can request them specifically.
+ * Otherwise we'll provide a context-aware default.
+ *
+ * If you have custom hardcoded color schemes that can be used on qz.com,
+ * define it here. Other color schemes are defined in the CMS (e.g., for a
+ * series or guide).
+ *
+ * A color scheme contains at least four colors. Order matters.
+ *
+ * 1. Typography: Default font color.
+ * 2. Background 1: Background color of the page.
+ * 3. Accent 1: The color of focused interactive borders, accented color blocks,
+ *    article text links, certain headings and more.
+ * 4. UI: The color of the site logo and other chrome in the navigation and
+ *    around the site.
+ *
+ * Optional:
+ *
+ * 5. Interactive border: border color used for interactive borders, e.g.,
+ *    checkboxes, text inputs and other form elements. Defaults to Typography
+ *    with 30% alpha channel.
+ * 6. Background 2: a tint of the background color, e.g. for alternating page
+ *    sections. Defaults to Background 1.
+ * 7. Background 3: a second tint of the background color. Defaults to
+ *    Typography with 10% alpha channel.
+ * 8. Navigation background: background of the navigation and tab bar. Defaults
+ *    to Background 1.
+ */
+export const schemes = {
+	LIGHT: {
+		accent: colors[ 'accent-blue' ],
+		background1: colors[ 'off-white' ],
+		background2: colors.white,
+		background3: null,
+		background4: colors.white,
+		borderInteractive: null,
+		typography: colors.black,
+		ui: colors.black,
+	},
+	DARK: {
+		accent: colors[ 'accent-blue-dark' ],
+		background1: colors[ 'dark-blue' ],
+		background2: colors[ 'dark-blue' ],
+		background3: null,
+		background4: null,
+		borderInteractive: null,
+		typography: colors.white,
+		ui: colors.white,
+	},
+	PRINT: {
+		accent: '#000',
+		background1: 'transparent',
+		typography: '#000',
+		ui: '#000',
+	},
+	WORK_LIGHT: {
+		accent: colors.teal,
+		background1: colors[ 'off-white' ],
+		background2: null,
+		background3: null,
+		background4: null,
+		borderInteractive: null,
+		typography: colors.black,
+		ui: colors[ 'dark-gray' ],
+	},
+	WORK_DARK: {
+		accent: colors[ 'light-teal' ],
+		background1: colors.teal,
+		background2: null,
+		background3: null,
+		background4: null,
+		borderInteractive: null,
+		typography: colors.white,
+		ui: colors.white,
+	},
+};
+
+/**
+ * Helper function to construct a CSS rgba value.
+ *
+ * @param  {Number} r Red value.
+ * @param  {Number} g Green value.
+ * @param  {Number} b Blue value.
+ * @param  {Number} a Alpha value.
+ * @return {String}
+ */
+function createRgba( r, g, b, a ) {
+	return `rgba( ${r}, ${g}, ${b}, ${a})`;
+}
+
+function getCss ( {
+	accent,
+	background1,
+	background2,
+	background3,
+	background4,
+	borderInteractive,
+	type,
+	typography,
+	ui,
+} ) {
+	// Print color schemes are simpler.
+	if ( 'print' === type ) {
+		return `
+			@media print {
+				:root {
+					--color-accent: ${accent};
+					--color-background-1: ${background1};
+					--color-background-1-transparent: transparent;
+					--color-background-2: transparent;
+					--color-background-3: transparent;
+					--color-background-4: transparent;
+					--color-background-5: transparent;
+					--color-background-navigation: transparent;
+					--color-border-decorative: ${ui};
+					--color-border-interactive: ${ui};
+					--color-typography: ${typography};
+					--color-typography-faint: ${typography};
+					--color-ui: ${ui};
+				}
+			}`;
+	}
+
+	// Colors derived from the typography color:
+	const typographyRgb = hexToRgb( typography );
+	const typographyFaint = createRgba( ...typographyRgb, 0.7 ); // A fainter tint of the typography color, eg. for descriptions or subheadings.
+	const borderDecorative = createRgba( ...typographyRgb, 0.15 );
+	const background5 = createRgba( ...typographyRgb, 0.07 );
+
+	// Colors derived from the background color:
+	const backgroundRgb = hexToRgb( background1 );
+	const fakeTransparent = createRgba( ...backgroundRgb, 0.0001 ); // Fake transparent (i.e. for the paywall gradient)
+	const backgroundModal = createRgba( ...backgroundRgb, 0.98 );
+
+	// Fallback colors:
+	const backgroundFallback = createRgba( ...typographyRgb, 0.15 );
+	const borderInteractiveFallback = createRgba( ...typographyRgb, 0.3 );
+
+	const css = `
+			:root {
+				--color-accent: ${accent};
+				--color-background-1: ${background1};
+				--color-background-1-transparent: ${fakeTransparent};
+				--color-background-2: ${background2 || background1};
+				--color-background-3: ${background3 || backgroundFallback};
+				--color-background-4: ${background4 || backgroundFallback};
+				--color-background-5: ${background5};
+				--color-background-modal: ${backgroundModal};
+				--color-border-decorative: ${borderDecorative};
+				--color-border-interactive: ${borderInteractive || borderInteractiveFallback};
+				--color-typography: ${typography};
+				--color-typography-faint: ${typographyFaint};
+				--color-ui: ${ui};
+			}
+		`;
+
+	if ( 'default' !== type ) {
+		return `@media (prefers-color-scheme: ${type}) { ${css} }`;
+	}
+
+	return css;
+}
+
+function ColorScheme( {
+	accent,
+	background1,
+	background2,
+	background3,
+	background4,
+	borderInteractive,
+	type,
+	typography,
+	ui,
+} ) {
+	// Destructuring and reassembling ensures we don't have any hidden
+	// dependencies in our props (and pleases the linter).
+	const props = {
+		accent,
+		background1,
+		background2,
+		background3,
+		background4,
+		borderInteractive,
+		type,
+		typography,
+		ui,
+	};
+
+	return <style type="text/css">{minifyCss( getCss( props ) )}</style>;
+};
+
+ColorScheme.propTypes = {
+	/**
+	 * The color used for borders of focused interactive elements, accented
+	 * color blocks, article text links, certain headings, and more.
+	 */
+	accent: PropTypes.string.isRequired,
+
+	/**
+	 * Primary background color of the page.
+	 */
+	background1: PropTypes.string.isRequired,
+
+	/**
+	 * A tint of the background color, e.g., for alternating page sections.
+	 * Defaults to `background1`.
+	 */
+	background2: PropTypes.string,
+
+	/**
+	 * A second tint of the background color. Defaults to `typography` with
+	 * 10% alpha channel.
+	 */
+	background3: PropTypes.string,
+
+	/**
+	 * A third tint of the background color. Defaults to `typography` with 10%
+	 * alpha channel.
+	 */
+	background4: PropTypes.string,
+
+	/**
+	 * The color used for borders of unfocsed form elements. Defaults to
+	 * `typography` with 30% alpha channel.
+	 */
+	borderInteractive: PropTypes.string,
+
+	/**
+	 * The color scheme type. If a value other than `default` or `print` is
+	 * provided, the definition will be wrapped in a `prefers-color-scheme`
+	 * media query.
+	 */
+	type: PropTypes.oneOf( [ 'dark', 'default', 'light', 'print' ] ).isRequired,
+
+	/**
+	 * Default type color.
+	 */
+	typography: PropTypes.string.isRequired,
+
+	/**
+	 * The color of the site logo and other chrome in the site navigation.
+	 */
+	ui: PropTypes.string.isRequired,
+};
+
+export default ColorScheme;

--- a/src/components/ColorScheme/ColorScheme.stories.mdx
+++ b/src/components/ColorScheme/ColorScheme.stories.mdx
@@ -38,7 +38,7 @@ automatically from base values.
 - **Do** supply colors in hexadecimal notation, e.g., `#000000`.
 - **Do** define official color schemes inside Prism alongside the existing `schemes`.
 - **Do** use colors from `@quartz/styles` when defining color schemes, modifying it if needed.
-- **Do** use `Helmet` (or your preferred `<head>` manager) to `ColorScheme` into the `<head>`.
+- **Do** use `Helmet` (or your preferred `<head>` manager) to hoist `ColorScheme` into the `<head>`.
 - **Do** supply a print `ColorScheme`.
 
 ## Props

--- a/src/components/ColorScheme/ColorScheme.stories.mdx
+++ b/src/components/ColorScheme/ColorScheme.stories.mdx
@@ -38,7 +38,7 @@ automatically from base values.
 - **Do** supply colors in hexadecimal notation, e.g., `#000000`.
 - **Do** define official color schemes inside Prism alongside the existing `schemes`.
 - **Do** use colors from `@quartz/styles` when defining color schemes, modifying it if needed.
-- **Do** wrap `ColorScheme` in `Helmet` to hoist it to the `<head>`.
+- **Do** use `Helmet` (or your preferred `<head>` manager) to `ColorScheme` into the `<head>`.
 - **Do** supply a print `ColorScheme`.
 
 ## Props

--- a/src/components/ColorScheme/ColorScheme.stories.mdx
+++ b/src/components/ColorScheme/ColorScheme.stories.mdx
@@ -1,0 +1,69 @@
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+import Button from '../Button/Button';
+import ColorScheme, { schemes } from './ColorScheme';
+
+<Meta title="ColorScheme" component={ColorScheme} />
+
+# ColorScheme
+
+`ColorScheme` defines CSS color variables that can be used by other components
+to make themselves "theme-aware." A `ColorScheme` is generally rendered at the
+page level to define the color scheme of that page.
+
+Render multiple `ColorScheme`s with different `type` props to create an
+environment that responds to the user's preferences (e.g., "dark mode" /
+"light mode"):
+
+```js
+import { ColorScheme, schemes } from '@quartz/interface';
+
+function MyPage() {
+	return (
+		<>
+			<ColorScheme {...schemes.LIGHT} type="default" />
+			<ColorScheme {...schemes.DARK} type="dark" />
+			<ColorScheme {...schemes.PRINT} type="print" />
+			<h1>Hello, world!</h1>
+		</>
+	);
+}
+```
+
+Some colors are optional; note the described fallback behavior in the prop
+descriptions. Other color values are not configurable and are calculated
+automatically from base values.
+
+## Usage guidelines
+
+- **Do** supply colors in hexadecimal notation, e.g., `#000000`.
+- **Do** define official color schemes inside Prism alongside the existing `schemes`.
+- **Do** use colors from `@quartz/styles` when defining color schemes, modifying it if needed.
+- **Do** wrap `ColorScheme` in `Helmet` to hoist it to the `<head>`.
+- **Do** supply a print `ColorScheme`.
+
+## Props
+
+The `Button` is rendered to show how it responds to `ColorScheme`. Also, note
+that because we are providing our own `ColorScheme` for this story, it will not
+respond to the theming toolbar—here or in the Canvas tab.
+
+<Canvas>
+	<Story
+		args={{
+			...schemes.LIGHT,
+			type: 'default',
+		}}
+		name="Default"
+	>
+		{
+			args => (
+				<>
+					<ColorScheme {...args} />
+					<Button>Hello!</Button>
+				</>
+			)
+		}
+	</Story>
+</Canvas>
+
+<ArgsTable story="Default" />

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,8 +1,10 @@
+export { default as Badge } from './Badge/Badge';
 export { default as BadgeGroup } from './BadgeGroup/BadgeGroup';
 export { default as Button, ButtonLabel } from './Button/Button';
 export { default as Blockquote } from './Blockquote/Blockquote';
 export { default as CalloutCard } from './CalloutCard/CalloutCard';
 export { default as Checkbox } from './Checkbox/Checkbox';
+export { default as ColorScheme, schemes } from './ColorScheme/ColorScheme';
 export { EmojiList, StructuredEmojiList } from './EmojiList/EmojiList';
 export { default as Image } from './Image/Image';
 export { default as RadioButton } from './RadioButton/RadioButton';


### PR DESCRIPTION
Adapt `ColorScheme` for Prism and use a theming addon to make it possible to preview components in different color schemes! 🎉 

![color-scheme](https://user-images.githubusercontent.com/739304/91205819-2d8ea600-e6d4-11ea-860f-9a20db074af2.gif)

The behavior of `ColorScheme` has been modified to accept one scheme at a time. This makes it a lot easier to understand and use, but means that for most use cases you need to render multiple `ColorScheme`s, not just one. Which kinda makes sense!

Note that we are not theming Storybook itself, which will remain in "light" mode. This tracks how other addons like `viewport` work: You use them to alter the Canvas, but they don't affect Storybook itself.