### PR TITLE
SVG importing doesn't work with qz-react

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,3 +1,0 @@
-// __mocks__/fileMock.js
-
-module.exports = 'test-file-stub';

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,6 @@
 module.exports = {
 	moduleNameMapper: {
 		'^.+\\.s?css$': 'identity-obj-proxy',
-		'\\.(svg)$': '<rootDir>/__mocks__/fileMock.js',
 	},
 	setupFiles: [
 		'./jest.setup.js',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9748,26 +9748,6 @@
         "randomfill": "^1.0.3"
       }
     },
-    "css": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.5.2",
-        "urix": "^0.1.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
     "css-loader": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
@@ -21907,12 +21887,6 @@
         "aproba": "^1.1.1"
       }
     },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
-      "dev": true
-    },
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
@@ -24706,51 +24680,6 @@
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "dev": true
     },
-    "svg-react-loader": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/svg-react-loader/-/svg-react-loader-0.4.6.tgz",
-      "integrity": "sha512-HVEypjWQsQuJdBIPzXGxpmQsQts7QwfQuYgK1rah6BVCMoLNSCh/ESKVNd7/tHq8DkWYHHTyaUMDA1FjqZYrgA==",
-      "dev": true,
-      "requires": {
-        "css": "2.2.4",
-        "loader-utils": "1.1.0",
-        "ramda": "0.21.0",
-        "rx": "4.1.0",
-        "traverse": "0.6.6",
-        "xml2js": "0.4.17"
-      },
-      "dependencies": {
-        "big.js": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-          "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-          "dev": true
-        },
-        "emojis-list": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-          "dev": true
-        },
-        "loader-utils": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true,
-          "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0"
-          }
-        }
-      }
-    },
     "svg-tags": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
@@ -25238,12 +25167,6 @@
       "requires": {
         "punycode": "^2.1.1"
       }
-    },
-    "traverse": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-      "dev": true
     },
     "trim": {
       "version": "0.0.1",
@@ -26635,25 +26558,6 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
-    },
-    "xml2js": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-      "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
-      "dev": true,
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "^4.1.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-      "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.0.0"
-      }
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
 	"files": [
 		"src/**/*.js",
 		"src/**/*.jsx",
-		"src/**/*.scss",
-		"src/**/*.svg"
+		"src/**/*.scss"
 	],
 	"dependencies": {
 		"@quartz/js-utils": "github:Quartz/js-utils#f7a4ea1"
@@ -52,7 +51,6 @@
 		"sass-loader": "^9.0.2",
 		"storybook-addon-themes": "^5.4.1",
 		"style-loader": "^1.2.1",
-		"stylelint": "^13.6.1",
-		"svg-react-loader": "^0.4.6"
+		"stylelint": "^13.6.1"
 	}
 }

--- a/src/components/Select/Select.jsx
+++ b/src/components/Select/Select.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames/bind';
 import styles from './Select.scss';
-import ExpandArrowDown from '../../svg/expand-arrow-down.svg';
 
 const cx = classnames.bind( styles );
 
@@ -47,10 +46,20 @@ const Select = ( {
 						</option>
 					) )}
 				</select>
-				<ExpandArrowDown
-					className={cx( 'down-arrow', { invalid } )}
+				<svg
 					aria-hidden="true"
-				/>
+					className={cx( 'down-arrow', { invalid } )}
+					height="6"
+					width="11"
+					viewBox="15 20 11 6"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<path
+						d="M20.027 26l.016-.016 1.088-1.062 3.887-3.859L23.932 20l-3.894 3.852L16.104 20l-1.086 1.064 3.964 3.881z"
+						fillRule="evenodd"
+						style={{ fill: 'var(--color, #4C4C4C)' }}
+					/>
+				</svg>
 			</div>
 		</label>
 		{

--- a/src/svg/expand-arrow-down.svg
+++ b/src/svg/expand-arrow-down.svg
@@ -1,1 +1,0 @@
-<svg width="11" height="6" viewBox="15 20 11 6" xmlns="http://www.w3.org/2000/svg"><path style="fill:var(--color, #4C4C4C)" fill-rule="evenodd" d="M20.027 26l.016-.016 1.088-1.062 3.887-3.859L23.932 20l-3.894 3.852L16.104 20l-1.086 1.064 3.964 3.881z"/></svg>


### PR DESCRIPTION
I'm not sure exactly why, but we can't yet `import` SVGs in Prism without breaking qz-react. It works in Prism but not in qz-react. Because Webpack? 