### PR TITLE
PageHeader QA

### DIFF
--- a/src/components/PageHeader/PageHeader.jsx
+++ b/src/components/PageHeader/PageHeader.jsx
@@ -3,22 +3,30 @@ import PropTypes from 'prop-types';
 import Tagline from '../Tagline/Tagline';
 import styles from './PageHeader.scss';
 
-const PageHeader = ( { border, children, intro, tagline, title } ) => (
-	<div className={`${styles.container} ${border ? styles.border : ''}`}>
-		<div className={styles.contents}>
-			<h1 className={styles.title}>{title}</h1>
-			{
-				tagline &&
-					<div className={styles.tagline}>
-						<Tagline>{tagline}</Tagline>
-					</div>
-			}
-			{
-				intro &&
-					<p className={styles.intro}>{intro}</p>
-			}
-		</div>
-		{children}
+const PageHeader = ( {
+	border,
+	children,
+	intro,
+	showPadding,
+	tagline,
+	title,
+} ) => (
+	<div className={`${styles.container} ${border ? styles.border : ''} ${showPadding ? styles.showPadding : ''}`}>
+		<h1 className={styles.title}>{title}</h1>
+		{
+			tagline &&
+				<div className={styles.tagline}>
+					<Tagline>{tagline}</Tagline>
+				</div>
+		}
+		{
+			intro &&
+				<p className={styles.intro}>{intro}</p>
+		}
+		{
+			children &&
+				<div className={styles.children}>{children}</div>
+		}
 	</div>
 );
 
@@ -39,6 +47,11 @@ PageHeader.propTypes = {
 	intro: PropTypes.node,
 
 	/**
+	 * Boolean to determine whether to add padding to the header before the bottom border.
+	 */
+	showPadding: PropTypes.bool.isRequired,
+
+	/**
 	 * Very small-print text used directly below the title (e.g., as a dateline).
 	 */
 	tagline: PropTypes.node,
@@ -51,6 +64,7 @@ PageHeader.propTypes = {
 
 PageHeader.defaultProps = {
 	border: true,
+	showPadding: true,
 };
 
 export default PageHeader;

--- a/src/components/PageHeader/PageHeader.jsx
+++ b/src/components/PageHeader/PageHeader.jsx
@@ -12,17 +12,19 @@ const PageHeader = ( {
 	title,
 } ) => (
 	<div className={`${styles.container} ${border ? styles.border : ''} ${showPadding ? styles.showPadding : ''}`}>
-		<h1 className={styles.title}>{title}</h1>
-		{
-			tagline &&
-				<div className={styles.tagline}>
-					<Tagline>{tagline}</Tagline>
-				</div>
-		}
-		{
-			intro &&
-				<p className={styles.intro}>{intro}</p>
-		}
+		<div className={styles.contents}>
+			<h1 className={styles.title}>{title}</h1>
+			{
+				tagline &&
+					<div className={styles.tagline}>
+						<Tagline>{tagline}</Tagline>
+					</div>
+			}
+			{
+				intro &&
+					<p className={styles.intro}>{intro}</p>
+			}
+		</div>
 		{
 			children &&
 				<div className={styles.children}>{children}</div>

--- a/src/components/PageHeader/PageHeader.scss
+++ b/src/components/PageHeader/PageHeader.scss
@@ -4,20 +4,31 @@
 @import '~@quartz/styles/scss/media-queries';
 
 .container {
+	margin-top: 20px;
 	text-align: center;
+
+	@include for-tablet-landscape-up {
+		margin-top: 48px;
+	}
 
 	&.border {
 		border-bottom: $border-solid-decorative;
 	}
+
+	&.show-padding {
+		padding-bottom: 28px;
+
+		@include for-tablet-landscape-up {
+			padding-bottom: 60px;
+		}
+	}
 }
 
-.contents {
-	margin-top: 20px;
-	margin-bottom: 24px;
+.children {
+	margin-top: 16px;
 
-	@include for-tablet-portrait-up {
-		margin-top: 48px;
-		margin-bottom: 60px;
+	@include for-tablet-landscape-up {
+		margin-top: 24px;
 	}
 }
 
@@ -28,18 +39,19 @@
 }
 
 .tagline {
-	max-width: 500px;
 	margin: 12px auto;
+	max-width: 500px;
 }
 
 .intro {
 	@include font-maison-500-3;
 
-	max-width: 500px;
-	margin: 24px auto;
 	color: $color-typography-faint;
+	margin: 16px auto;
+	max-width: 500px;
 
 	@include for-tablet-portrait-up {
+		margin: 24px auto;
 		max-width: 600px;
 	}
 

--- a/src/components/PageHeader/PageHeader.scss
+++ b/src/components/PageHeader/PageHeader.scss
@@ -2,10 +2,10 @@
 @import '~@quartz/styles/scss/color-scheme';
 @import '~@quartz/styles/scss/fonts';
 @import '~@quartz/styles/scss/media-queries';
+@import '~@quartz/styles/scss/tokens';
 
 .container {
 	margin-top: 20px;
-	text-align: center;
 
 	@include for-tablet-landscape-up {
 		margin-top: 48px;
@@ -29,6 +29,19 @@
 
 	@include for-tablet-landscape-up {
 		margin-top: 24px;
+	}
+}
+
+.contents {
+	padding: 0 $size-gutter-mobile;
+	text-align: center;
+
+	@include for-tablet-portrait-up {
+		padding: 0 $size-gutter-tablet;
+	}
+
+	@include for-tablet-landscape-up {
+		padding: 0 $size-gutter-desktop;
 	}
 }
 

--- a/src/components/PageHeader/PageHeader.stories.mdx
+++ b/src/components/PageHeader/PageHeader.stories.mdx
@@ -66,6 +66,7 @@ It takes optional children, which should be navigation elements (tabs, search ba
 <Canvas>
 	<Story
 		args={{
+			showPadding: false,
 			title: "Good morning, USA",
 			children: (
 				<TabNav>
@@ -88,6 +89,7 @@ It takes optional children, which should be navigation elements (tabs, search ba
 	<Story
 		args={{
 			intro: "I’ve got a feeling that it’s gonna be a wonderful day.",
+			showPadding: false,
 			title: "Good morning, USA",
 			tagline: "Last updated 3 hours ago",
 			children: (


### PR DESCRIPTION
Some PageHeader QA from Living Briefing. The children prop sometimes accepts components like TabNav that we want flush against the rule, and other times accepts components that should have some healthy padding between it and the rule. Not sure how to do this without a prop like `showPadding`. Other suggestions welcome.