### PR TITLE
Adding another size to Hed

### DIFF
--- a/src/components/Hed/Hed.jsx
+++ b/src/components/Hed/Hed.jsx
@@ -22,7 +22,7 @@ Hed.propTypes = {
 	/**
 	 * The size of the headline.
 	 */
-	size: PropTypes.oneOf( [ 'small', 'medium', 'large' ] ).isRequired,
+	size: PropTypes.oneOf( [ 'small', 'medium', 'large', 'extra-large' ] ).isRequired,
 };
 
 Hed.defaultProps = {

--- a/src/components/Hed/Hed.scss
+++ b/src/components/Hed/Hed.scss
@@ -15,5 +15,9 @@
 }
 
 .large {
+	@include font-maison-800-5;
+}
+
+.extra-large {
 	@include font-maison-800-7;
 }

--- a/src/components/TextGroup/TextGroup.jsx
+++ b/src/components/TextGroup/TextGroup.jsx
@@ -48,7 +48,7 @@ TextGroup.propTypes = {
 	 * Size preset for the text group. Adjusts the font size and spacing
 	 * of the headline (Hed component).
 	 */
-	size: PropTypes.oneOf( [ 'small', 'medium', 'large' ] ),
+	size: PropTypes.oneOf( [ 'small', 'medium', 'large', 'extra-large' ] ),
 
 	/**
 	 * Tagline to appear beneath the title.

--- a/src/components/TextGroup/TextGroup.scss
+++ b/src/components/TextGroup/TextGroup.scss
@@ -9,7 +9,8 @@
 		color: $color-accent;
 	}
 
-	&.large {
+	&.large,
+	&.extra-large {
 		@include for-tablet-landscape-up {
 			margin-bottom: 8px;
 		}
@@ -19,7 +20,8 @@
 .tagline {
 	margin-top: 4px;
 
-	&.large {
+	&.large,
+	&.extra-large {
 		@include for-tablet-landscape-up {
 			margin-top: 8px;
 		}

--- a/src/components/TextGroup/TextGroup.stories.mdx
+++ b/src/components/TextGroup/TextGroup.stories.mdx
@@ -77,6 +77,21 @@ described content.
 	</Story>
 </Canvas>
 
+### Extra-Large
+
+<Canvas>
+	<Story
+		args={{
+			size: 'extra-large',
+			tagline: 'The concise, conversational rundown you need to start your day.',
+			title: 'Quartz Daily Brief',
+		}}
+		name="Extra-Large"
+	>
+		{args => <TextGroup {...args} />}
+	</Story>
+</Canvas>
+
 ### Taxonomy
 
 <Canvas>


### PR DESCRIPTION
We often use the 800-5 mixin, and specifically need it for the Living Briefing, so I'm adding another size to the `Hed` component.