### PR TITLE
Simplify color schemes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4918,8 +4918,8 @@
       }
     },
     "@quartz/styles": {
-      "version": "github:Quartz/styles#60ba6774ac7fa59533e4da696f522e6ccb54b680",
-      "from": "github:Quartz/styles#60ba677",
+      "version": "github:Quartz/styles#f049b4aac145b875b55a041406218e6919574cc6",
+      "from": "github:Quartz/styles#f049b4a",
       "dev": true,
       "requires": {
         "normalize.css": "^8.0.1"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"@babel/preset-react": "^7.10.4",
 		"@quartz/eslint-config-react": "^1.0.4",
 		"@quartz/stylelint-config": "^1.0.0",
-		"@quartz/styles": "github:Quartz/styles#60ba677",
+		"@quartz/styles": "github:Quartz/styles#f049b4a",
 		"@storybook/addon-a11y": "^6.0.10",
 		"@storybook/addon-essentials": "^6.0.10",
 		"@storybook/addon-links": "^6.0.10",

--- a/src/components/ColorScheme/ColorScheme.jsx
+++ b/src/components/ColorScheme/ColorScheme.jsx
@@ -47,29 +47,20 @@ export const schemes = {
 		accent: colors[ 'accent-blue' ],
 		background1: colors[ 'off-white' ],
 		background2: colors.white,
-		background3: null,
-		background4: colors.white,
-		borderInteractive: null,
 		highlight: createRgba( ...hexToRgb( colors[ 'accent-blue' ] ), 0.2 ),
 		typography: colors.black,
-		ui: colors.black,
 	},
 	DARK: {
 		accent: colors[ 'accent-blue-dark' ],
 		background1: colors[ 'dark-blue' ],
 		background2: colors[ 'dark-blue' ],
-		background3: null,
-		background4: null,
-		borderInteractive: null,
 		highlight: createRgba( ...hexToRgb( colors.pink ), 0.25 ),
 		typography: colors.white,
-		ui: colors.white,
 	},
 	PRINT: {
 		accent: '#000',
 		background1: 'transparent',
 		typography: '#000',
-		ui: '#000',
 	},
 };
 
@@ -90,13 +81,9 @@ function getCss ( {
 	accent,
 	background1,
 	background2,
-	background3,
-	background4,
-	borderInteractive,
 	highlight,
 	type,
 	typography,
-	ui,
 } ) {
 	// Print color schemes are simpler.
 	if ( 'print' === type ) {
@@ -109,14 +96,12 @@ function getCss ( {
 					--color-background-2: transparent;
 					--color-background-3: transparent;
 					--color-background-4: transparent;
-					--color-background-5: transparent;
 					--color-background-navigation: transparent;
-					--color-border-decorative: ${ui};
-					--color-border-interactive: ${ui};
+					--color-border-decorative: ${typography};
+					--color-border-interactive: ${typography};
 					--color-highlight: transparent;
 					--color-typography: ${typography};
 					--color-typography-faint: ${typography};
-					--color-ui: ${ui};
 				}
 			}`;
 	}
@@ -125,16 +110,14 @@ function getCss ( {
 	const typographyRgb = hexToRgb( typography );
 	const typographyFaint = createRgba( ...typographyRgb, 0.7 ); // A fainter tint of the typography color, eg. for descriptions or subheadings.
 	const borderDecorative = createRgba( ...typographyRgb, 0.15 );
-	const background5 = createRgba( ...typographyRgb, 0.07 );
+	const borderInteractive = createRgba( ...typographyRgb, 0.3 );
+	const background3 = createRgba( ...typographyRgb, 0.15 );
+	const background4 = createRgba( ...typographyRgb, 0.07 );
 
 	// Colors derived from the background color:
 	const backgroundRgb = hexToRgb( background1 );
 	const fakeTransparent = createRgba( ...backgroundRgb, 0.0001 ); // Fake transparent (i.e. for the paywall gradient)
 	const backgroundModal = createRgba( ...backgroundRgb, 0.98 );
-
-	// Fallback colors:
-	const backgroundFallback = createRgba( ...typographyRgb, 0.15 );
-	const borderInteractiveFallback = createRgba( ...typographyRgb, 0.3 );
 
 	const css = `
 			:root {
@@ -142,16 +125,14 @@ function getCss ( {
 				--color-background-1: ${background1};
 				--color-background-1-transparent: ${fakeTransparent};
 				--color-background-2: ${background2 || background1};
-				--color-background-3: ${background3 || backgroundFallback};
-				--color-background-4: ${background4 || backgroundFallback};
-				--color-background-5: ${background5};
+				--color-background-3: ${background3};
+				--color-background-4: ${background4};
 				--color-background-modal: ${backgroundModal};
 				--color-border-decorative: ${borderDecorative};
-				--color-border-interactive: ${borderInteractive || borderInteractiveFallback};
+				--color-border-interactive: ${borderInteractive};
 				--color-highlight: ${highlight || borderDecorative};
 				--color-typography: ${typography};
 				--color-typography-faint: ${typographyFaint};
-				--color-ui: ${ui};
 			}
 		`;
 
@@ -166,13 +147,9 @@ function ColorScheme( {
 	accent,
 	background1,
 	background2,
-	background3,
-	background4,
-	borderInteractive,
 	highlight,
 	type,
 	typography,
-	ui,
 } ) {
 	// Destructuring and reassembling ensures we don't have any hidden
 	// dependencies in our props (and pleases the linter).
@@ -180,13 +157,9 @@ function ColorScheme( {
 		accent,
 		background1,
 		background2,
-		background3,
-		background4,
-		borderInteractive,
 		highlight,
 		type,
 		typography,
-		ui,
 	};
 
 	return <style type="text/css">{minifyCss( getCss( props ) )}</style>;
@@ -211,24 +184,6 @@ ColorScheme.propTypes = {
 	background2: PropTypes.string,
 
 	/**
-	 * A second tint of the background color. Defaults to `typography` with
-	 * 10% alpha channel.
-	 */
-	background3: PropTypes.string,
-
-	/**
-	 * A third tint of the background color. Defaults to `typography` with 10%
-	 * alpha channel.
-	 */
-	background4: PropTypes.string,
-
-	/**
-	 * The color used for borders of unfocsed form elements. Defaults to
-	 * `typography` with 30% alpha channel.
-	 */
-	borderInteractive: PropTypes.string,
-
-	/**
 	 * The background color used for highlighting text or other UI elements for
 	 * emphasis. Defaults to `typography` with 15% alpha channel.
 	 */
@@ -245,11 +200,6 @@ ColorScheme.propTypes = {
 	 * Default type color.
 	 */
 	typography: PropTypes.string.isRequired,
-
-	/**
-	 * The color of the site logo and other chrome in the site navigation.
-	 */
-	ui: PropTypes.string.isRequired,
 };
 
 export default ColorScheme;


### PR DESCRIPTION
Since we removed Quartz at Work, several of the color scheme overrides are unused. We also no longer need 5 background colors or a separate color for nav components (`color-ui`)

This PR simplifies ColorScheme by removing these overrides and unused colors.
