### PR TITLE
Emoji classnames

### DIFF
--- a/src/components/EmojiList/EmojiList.jsx
+++ b/src/components/EmojiList/EmojiList.jsx
@@ -79,7 +79,7 @@ const EmojiList = ( {
 	renderStyles,
 	tagName,
 } ) => {
-	const emojiId = [ 'bullets', ...bullets].join( '-' );
+	const emojiId = [ 'bullets', ...bullets ].join( '-' );
 
 	return (
 		<>

--- a/src/components/EmojiList/EmojiList.jsx
+++ b/src/components/EmojiList/EmojiList.jsx
@@ -79,8 +79,7 @@ const EmojiList = ( {
 	renderStyles,
 	tagName,
 } ) => {
-	const emojiId = 'testymctest';
-	// bullets.join( '-' );
+	const emojiId = [ 'bullets', ...bullets].join( '-' );
 
 	return (
 		<>

--- a/src/components/EmojiList/EmojiList.jsx
+++ b/src/components/EmojiList/EmojiList.jsx
@@ -79,7 +79,8 @@ const EmojiList = ( {
 	renderStyles,
 	tagName,
 } ) => {
-	const emojiId = bullets.join( '-' );
+	const emojiId = 'testymctest';
+	// bullets.join( '-' );
 
 	return (
 		<>


### PR DESCRIPTION
Certain emojis do not work as the beginning of a CSS identifer. 

The one that crashes it is 1️⃣, which is a sequence emoji beginning with ... U+0031, or digit one.

> In CSS, identifiers (including element names, classes, and IDs in selectors) can contain only the characters [a-zA-Z0-9] and ISO 10646 characters U+00A0 and higher, plus the hyphen (-) and the underscore (_); _they cannot start with a digit_, two hyphens, or a hyphen followed by a digit. Identifiers can also contain escaped characters and any ISO 10646 character as a numeric code (see next item). For instance, the identifier "B&W?" may be written as "B\&W\?" or "B\26 W\3F".

https://www.w3.org/TR/CSS21/syndata.html#characters
https://stackoverflow.com/questions/448981/which-characters-are-valid-in-css-class-names-selectors