### PR TITLE
Add missing passthrough to barrel file for ArticleStrip

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,4 @@
+export { default as ArticleStrip } from './ArticleStrip/ArticleStrip';
 export { default as Badge } from './Badge/Badge';
 export { default as BadgeGroup } from './BadgeGroup/BadgeGroup';
 export { default as Button, ButtonLabel } from './Button/Button';


### PR DESCRIPTION
Forgot to export new ArticleStrip component from components index