### PR TITLE
Support sponsors in article strips

### DIFF
--- a/src/components/ArticleStrip/ArticleStrip.jsx
+++ b/src/components/ArticleStrip/ArticleStrip.jsx
@@ -95,10 +95,12 @@ ArticleStrip.propTypes = {
 	size: PropTypes.oneOf( [ 'small', 'extra-large' ] ),
 
 	/**
-	 * If this is a 'bulletin' type article, passing in the name of the
-	 * company sponsoring the article will display a 'Sponsored by'
-	 * message instead of a kicker, even if a kicker is also provided.
-	 * A sponsored article will also not display an edition or timestamp.
+	 * If this article was written by Quartz Creative, i.e., it is a
+	 * 'bulletin' article, use this prop to provide the name of the
+	 * client sponsoring the article in order to display a 'Sponsor
+	 * content by' message instead of a kicker (even if a kicker is also
+	 * provided). Bulletin articles do not display an edition or
+	 * timestamp.
 	 */
 	sponsor: PropTypes.string,
 

--- a/src/components/ArticleStrip/ArticleStrip.jsx
+++ b/src/components/ArticleStrip/ArticleStrip.jsx
@@ -98,6 +98,7 @@ ArticleStrip.propTypes = {
 	 * If this is a 'bulletin' type article, passing in the name of the
 	 * company sponsoring the article will display a 'Sponsored by'
 	 * message instead of a kicker, even if a kicker is also provided.
+	 * A sponsored article will also not display an edition or timestamp.
 	 */
 	sponsor: PropTypes.string,
 

--- a/src/components/ArticleStrip/ArticleStrip.jsx
+++ b/src/components/ArticleStrip/ArticleStrip.jsx
@@ -23,30 +23,42 @@ const responsiveImagePropsMapping = {
 	},
 };
 
+function SponsoredBy( { sponsor } ) {
+	return <span className={styles.sponsoredBy}>Sponsor content <span className={styles.sponsor}>{`by ${sponsor}`}</span></span>;
+}
+
+SponsoredBy.propTypes = {
+	sponsor: PropTypes.string.isRequired,
+};
+
 function ArticleStrip ( {
 	dateGmt,
 	edition,
 	kicker,
 	size,
+	sponsor,
 	thumbnailUrl,
 	title,
 } ) {
 	return (
 		<div className={`${styles.container} ${styles[ size ]}`}>
-			<div className={`${styles.thumbnailContainer} ${styles[ size ]}`}>
-				<ResponsiveImage
-					alt=""
-					src={thumbnailUrl}
-					{...responsiveImagePropsMapping[ size ]}
-				/>
-			</div>
+			{
+				thumbnailUrl &&
+				<div className={`${styles.thumbnailContainer} ${styles[ size ]}`}>
+					<ResponsiveImage
+						alt=""
+						src={thumbnailUrl}
+						{...responsiveImagePropsMapping[ size ]}
+					/>
+				</div>
+			}
 			<div>
 				<TextGroup
 					isArticle={true}
-					kicker={kicker}
+					kicker={sponsor ? <SponsoredBy sponsor={sponsor} /> : kicker}
 					size={size}
 					title={title}
-					tagline={`${stylizedTimestamp( dateGmt )} • ${edition}`}
+					tagline={! sponsor && `${stylizedTimestamp( dateGmt )} • ${edition}`}
 				/>
 			</div>
 		</div>
@@ -59,7 +71,7 @@ ArticleStrip.propTypes = {
 	 * the Greenwich Mean Time (GMT-00:00:00). E.g.,
 	 * `'2012-09-04T17:02:10'`.
 	*/
-	dateGmt: PropTypes.string.isRequired,
+	dateGmt: PropTypes.string,
 
 	/**
 	 * The Quartz edition to which the article belongs.
@@ -69,7 +81,7 @@ ArticleStrip.propTypes = {
 		'Quartz Africa',
 		'Quartz India',
 		'Quartz at Work',
-	] ).isRequired,
+	] ),
 
 	/**
 	 * A short phrase that accompanies the hed. See [Kicker](/?path=/docs/kicker--default-story).
@@ -83,9 +95,16 @@ ArticleStrip.propTypes = {
 	size: PropTypes.oneOf( [ 'small', 'extra-large' ] ),
 
 	/**
+	 * If this is a 'bulletin' type article, passing in the name of the
+	 * company sponsoring the article will display a 'Sponsored by'
+	 * message instead of a kicker, even if a kicker is also provided.
+	 */
+	sponsor: PropTypes.string,
+
+	/**
 	 * URL of the thumbnail image from our WordPress media library.
 	 */
-	thumbnailUrl: PropTypes.string.isRequired,
+	thumbnailUrl: PropTypes.string,
 
 	/**
 	 * The article headline. See [Hed](/?path=/docs/hed--default-story)

--- a/src/components/ArticleStrip/ArticleStrip.scss
+++ b/src/components/ArticleStrip/ArticleStrip.scss
@@ -1,3 +1,4 @@
+@use '~@quartz/styles/scss/color-scheme';
 @use '~@quartz/styles/scss/media-queries';
 @use '~@quartz/styles/scss/tokens';
 
@@ -30,4 +31,12 @@
 			margin-right: 40px;
 		}
 	}
+}
+
+.sponsored-by {
+	color: tokens.$color-gold;
+}
+
+.sponsor {
+	color: color-scheme.$typography-faint;
 }

--- a/src/components/ArticleStrip/ArticleStrip.stories.mdx
+++ b/src/components/ArticleStrip/ArticleStrip.stories.mdx
@@ -67,3 +67,19 @@ A summary of a Quartz article, typically used when linking to that article in a 
 		{args => <ArticleStrip {...args} />}
 	</Story>
 </Canvas>
+
+### Sponsored article (a.k.a. bulletin)
+
+<Canvas>
+	<Story
+		args={{
+			size: 'extra-large',
+			sponsor: 'Citrix',
+			thumbnailUrl: 'https://cms.qz.com/wp-content/uploads/2018/11/Citrix_AB1-Twitter-B.png',
+			title: 'A renowned psychologist discusses the causes of FOMO in this audio interactive',
+		}}
+		name="Bulletin"
+	>
+		{args => <ArticleStrip {...args} />}
+	</Story>
+</Canvas>

--- a/src/components/ArticleStrip/ArticleStrip.stories.mdx
+++ b/src/components/ArticleStrip/ArticleStrip.stories.mdx
@@ -68,7 +68,7 @@ A summary of a Quartz article, typically used when linking to that article in a 
 	</Story>
 </Canvas>
 
-### Sponsored article (a.k.a. bulletin)
+### Sponsor content (a.k.a. bulletin)
 
 <Canvas>
 	<Story


### PR DESCRIPTION
Adds a `sponsor` prop to `ArticleStrip` so we can easily display sponsor information instead of a kicker, edition and dateline.

Also makes `dateGmt`, `edition` and `thumbnailUrl` props optional

![Screen Shot 2020-10-23 at 3 27 36 PM](https://user-images.githubusercontent.com/591884/97045739-4be21800-1544-11eb-921f-299e9825fc16.png)
