### PR TITLE
AMP-valid ArticleStrip

### DIFF
--- a/src/components/ArticleStrip/ArticleStrip.jsx
+++ b/src/components/ArticleStrip/ArticleStrip.jsx
@@ -32,6 +32,7 @@ SponsoredBy.propTypes = {
 };
 
 function ArticleStrip ( {
+	amp,
 	dateGmt,
 	edition,
 	kicker,
@@ -47,6 +48,7 @@ function ArticleStrip ( {
 				<div className={`${styles.thumbnailContainer} ${styles[ size ]}`}>
 					<ResponsiveImage
 						alt=""
+						amp={amp}
 						src={thumbnailUrl}
 						{...responsiveImagePropsMapping[ size ]}
 					/>
@@ -66,6 +68,12 @@ function ArticleStrip ( {
 }
 
 ArticleStrip.propTypes = {
+	/**
+	 * Whether to render the AMP-valid version of the thumbnail image
+	 * (`amp-img`).
+	 */
+	amp: PropTypes.bool.isRequired,
+
 	/**
 	 * A string-based representation of the article publish datetime at
 	 * the Greenwich Mean Time (GMT-00:00:00). E.g.,
@@ -116,6 +124,7 @@ ArticleStrip.propTypes = {
 };
 
 ArticleStrip.defaultProps = {
+	amp: false,
 	edition: 'Quartz',
 	size: 'small',
 };

--- a/src/components/Image/Image.jsx
+++ b/src/components/Image/Image.jsx
@@ -85,7 +85,8 @@ Image.propTypes = {
 	alt: PropTypes.string.isRequired,
 
 	/**
-	 * Whether to render the AMP version of the image.
+	 * Whether to render the AMP version of the image. See
+	 * https://amp.dev/documentation/components/amp-img/
 	 */
 	amp: PropTypes.bool.isRequired,
 

--- a/src/components/ResponsiveImage/ResponsiveImage.jsx
+++ b/src/components/ResponsiveImage/ResponsiveImage.jsx
@@ -5,6 +5,7 @@ import { arrayFromRange, resizeWPImage } from '@quartz/js-utils';
 
 function ResponsiveImage( {
 	alt,
+	amp,
 	fallbackHeight,
 	fallbackWidth,
 	sizes,
@@ -31,6 +32,7 @@ function ResponsiveImage( {
 	return (
 		<Image
 			alt={alt}
+			amp={amp}
 			sizes={sizes || sizesDefault}
 			src={resizeWPImage( src, fallbackWidth, fallbackHeight )}
 			srcSet={srcSet}
@@ -47,6 +49,12 @@ ResponsiveImage.propTypes = {
 	 * circumstances an empty string is preferred.
 	 */
 	alt: PropTypes.string.isRequired,
+
+	/**
+	 * Whether to render the AMP version of the image. See
+	 * https://amp.dev/documentation/components/amp-img/
+	 */
+	amp: PropTypes.bool.isRequired,
 
 	/**
 	 * The rendered height of the image when CSS cannot be loaded or in very old
@@ -91,6 +99,10 @@ ResponsiveImage.propTypes = {
 	 * and maximum values, e.g. `[ 100, 100 ]`.
 	 */
 	widthRange: PropTypes.arrayOf( PropTypes.number ).isRequired,
+};
+
+ResponsiveImage.defaultProps = {
+	amp: false,
 };
 
 export default ResponsiveImage;


### PR DESCRIPTION
Sadly I can't think of an another way round this problem: we have to support ArticleStrip on AMP pages, and that means drilling an `amp` prop all the way down to the `Image` component in order for it to render an `amp-img` tag. Any better suggestions very welcome