### PR TITLE
Add render prop to ColorScheme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2226,9 +2226,9 @@
 			}
 		},
 		"@quartz/js-utils": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@quartz/js-utils/-/js-utils-1.1.0.tgz",
-			"integrity": "sha512-oOWuWHwpmS9ki/5ho5BTdjEQPPxoLYDshhCbPRNQkZJ1i7RJAZv6H2pvdPrCW0xUE537ukYEJDhkxvH8JqakEQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@quartz/js-utils/-/js-utils-1.1.1.tgz",
+			"integrity": "sha512-z4dzY85hljdKin1VceLWJHDce9UOtook8zkH8sou1TnUS4kJxAiTUV9Pvhmtrke0+z/wXdDnFCwn141T1FSVSg==",
 			"dev": true
 		},
 		"@quartz/stylelint-config": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {},
 	"devDependencies": {
 		"@quartz/eslint-config-react": "^1.1.3",
-		"@quartz/js-utils": "^1.1.0",
+		"@quartz/js-utils": "^1.1.1",
 		"@quartz/stylelint-config": "^1.2.0",
 		"@quartz/styles": "github:Quartz/styles#aa7b8c0",
 		"@storybook/addon-a11y": "^6.0.10",

--- a/src/components/ColorScheme/ColorScheme.tsx
+++ b/src/components/ColorScheme/ColorScheme.tsx
@@ -5,12 +5,6 @@ import {
 } from '@quartz/js-utils';
 import { color } from '@quartz/styles/dictionaries/colors.json';
 
-// Reshape the color dictionary JSON for easier application
-const colors = Object.keys( color ).reduce( ( acc, colorName ) => ( {
-	...acc,
-	[ colorName ]: color[ colorName ].value,
-} ), {} );
-
 /**
  * Export some color schemes so that pages can request them specifically.
  * Otherwise we'll provide a context-aware default.
@@ -43,18 +37,18 @@ const colors = Object.keys( color ).reduce( ( acc, colorName ) => ( {
  */
 export const schemes = {
 	LIGHT: {
-		accent: colors[ 'accent-blue' ],
-		background1: colors[ 'off-white' ],
-		background2: colors.white,
-		highlight: createRgba( ...hexToRGB( colors[ 'accent-blue' ] ), 0.2 ),
-		typography: colors.black,
+		accent: color[ 'accent-blue' ].value,
+		background1: color[ 'off-white' ].value,
+		background2: color.white.value,
+		highlight: createRgba( ...hexToRGB( color[ 'accent-blue' ].value ), 0.2 ),
+		typography: color.black.value,
 	},
 	DARK: {
-		accent: colors[ 'accent-blue-dark' ],
-		background1: colors[ 'dark-blue' ],
-		background2: colors[ 'dark-blue' ],
-		highlight: createRgba( ...hexToRGB( colors.pink ), 0.25 ),
-		typography: colors.white,
+		accent: color[ 'accent-blue-dark' ].value,
+		background1: color[ 'dark-blue' ].value,
+		background2: color[ 'dark-blue' ].value,
+		highlight: createRgba( ...hexToRGB( color.pink.value ), 0.25 ),
+		typography: color.white.value,
 	},
 	PRINT: {
 		accent: '#000',
@@ -65,14 +59,8 @@ export const schemes = {
 
 /**
  * Helper function to construct a CSS rgba value.
- *
- * @param  {Number} r Red value.
- * @param  {Number} g Green value.
- * @param  {Number} b Blue value.
- * @param  {Number} a Alpha value.
- * @return {String}
  */
-function createRgba( r, g, b, a ) {
+function createRgba( r: number, g: number, b: number, a: number ): string {
 	return `rgba( ${r}, ${g}, ${b}, ${a})`;
 }
 

--- a/src/components/ColorScheme/ColorScheme.tsx
+++ b/src/components/ColorScheme/ColorScheme.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import {
 	hexToRGB,
 	minifyCss,
@@ -143,63 +142,64 @@ function getCss ( {
 	return css;
 }
 
-function ColorScheme( {
-	accent,
-	background1,
-	background2,
-	highlight,
-	type,
-	typography,
-} ) {
-	// Destructuring and reassembling ensures we don't have any hidden
-	// dependencies in our props (and pleases the linter).
-	const props = {
-		accent,
-		background1,
-		background2,
-		highlight,
-		type,
-		typography,
-	};
-
-	return <style type="text/css">{minifyCss( getCss( props ) )}</style>;
-}
-
-ColorScheme.propTypes = {
+export default function ColorScheme( props: {
 	/**
 	 * The color used for borders of focused interactive elements, accented
 	 * color blocks, article text links, certain headings, and more.
 	 */
-	accent: PropTypes.string.isRequired,
+	accent: string,
 
 	/**
 	 * Primary background color of the page.
 	 */
-	background1: PropTypes.string.isRequired,
+	background1: string,
 
 	/**
 	 * A tint of the background color, e.g., for alternating page sections.
 	 * Defaults to `background1`.
 	 */
-	background2: PropTypes.string,
+	background2?: string,
+
+	/**
+	 * An optional render prop if you need to use the CSS in a non-HTML context or
+	 * if you need to provide it to an external dependency like React Helmet.
+	 */
+	children?: ( css: string ) => JSX.Element,
 
 	/**
 	 * The background color used for highlighting text or other UI elements for
 	 * emphasis. Defaults to `typography` with 15% alpha channel.
 	 */
-	highlight: PropTypes.string,
+	highlight?: string,
 
 	/**
 	 * The color scheme type. If a value other than `default` or `print` is
 	 * provided, the definition will be wrapped in a `prefers-color-scheme`
 	 * media query.
 	 */
-	type: PropTypes.oneOf( [ 'dark', 'default', 'light', 'print' ] ).isRequired,
+	type: 'dark' | 'default' | 'light' | 'print',
 
 	/**
 	 * Default type color.
 	 */
-	typography: PropTypes.string.isRequired,
-};
+	typography: string,
+} ) {
+	// Reassembling ensures we don't have any hidden dependencies in our props (and
+	// pleases the linter).
+	const css = minifyCss(
+		getCss( {
+			accent: props.accent,
+			background1: props.background1,
+			background2: props.background2,
+			highlight: props.highlight,
+			type: props.type,
+			typography: props.typography,
+		} )
+	);
 
-export default ColorScheme;
+	if ( props.children ) {
+		return props.children( css );
+	}
+
+	return <style type="text/css">{css}</style>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,9 @@
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
+    "resolveJsonModule": true,
     "sourceMap": true,
-    "strictNullChecks": true,
+    "strictNullChecks": true
   },
   "include": [
     "src/components"


### PR DESCRIPTION
Add render prop to ColorScheme to allow us to render with React Helmet without baking React Helmet into Prism. Also converting to TS.