### PR TITLE
Radio should attempt to take up space even when inline

### DIFF
--- a/src/components/RadioButton/RadioButton.scss
+++ b/src/components/RadioButton/RadioButton.scss
@@ -8,13 +8,13 @@
 .container {
 	@include fonts.maison;
 
+	width: 100%;
 	display: inline-flex;
 	align-items: center;
 	cursor: pointer;
 
 	&.block {
 		display: flex;
-		width: 100%;
 	}
 }
 


### PR DESCRIPTION
Radio contents collapse when the radio is being used inline.

<img width="664" alt="Screen Shot 2020-11-03 at 11 08 24 AM" src="https://user-images.githubusercontent.com/12448396/98029955-23201500-1dc5-11eb-9c85-ec42563e0f14.png">

We can constrain this with a wrapping div, but it should take up the space it's allowed.

<img width="672" alt="Screen Shot 2020-11-03 at 11 09 19 AM" src="https://user-images.githubusercontent.com/12448396/98030002-329f5e00-1dc5-11eb-91e8-e5bcdab745e6.png">
