### PR TITLE
Add hint and invalid props to TextInput

### DIFF
--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -9,10 +9,6 @@
 
 	cursor: pointer;
 	display: flex;
-
-	&.has-error {
-		color: tokens.$color-red;
-	}
 }
 
 .input {

--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -1,23 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './TextInput.scss';
+import classnames from 'classnames/bind';
+
+const cx = classnames.bind( styles );
 
 const TextInput = ( {
-	autoComplete,
 	ariaDescribedBy,
+	autoComplete,
 	disabled,
-	isMultiline,
-	inputRef,
+	hint,
 	id,
+	inputRef,
+	invalid,
+	isMultiline,
 	label,
 	maxLength,
-	placeholder,
 	onBlur,
 	onChange,
 	onClick,
 	onFocus,
 	onInvalid,
 	pattern,
+	placeholder,
 	readOnly,
 	required,
 	type,
@@ -33,6 +38,7 @@ const TextInput = ( {
 				className={styles.textarea}
 				rows={6}
 				aria-describedby={ariaDescribedBy}
+				aria-invalid={invalid}
 				disabled={disabled}
 				id={id}
 				maxlength={maxLength}
@@ -53,6 +59,7 @@ const TextInput = ( {
 				className={styles.input}
 				type={type}
 				aria-describedby={ariaDescribedBy}
+				aria-invalid={invalid}
 				autoComplete={autoComplete}
 				disabled={disabled}
 				id={id}
@@ -70,6 +77,9 @@ const TextInput = ( {
 				required={required}
 			/>
 		}
+		<div className={cx( 'hint', { invalid } )}>
+			{hint}
+		</div>
 	</label>
 );
 
@@ -99,6 +109,10 @@ TextInput.propTypes = {
 	 */
 	disabled: PropTypes.bool.isRequired,
 	/**
+	 * Descriptive content displayed under the element, usually to provide context or instructions to the user (e.g. 'Password must be at least 6 characters' )
+	 */
+	hint: PropTypes.node.isRequired,
+	/**
 	 * HTML ID of the component. Forwarded to the input/textarea element.
 	 */
 	id: PropTypes.string,
@@ -106,6 +120,11 @@ TextInput.propTypes = {
 	 * Used in the event of forwarding an external ref to the tag.
 	 */
 	inputRef: PropTypes.object,
+	/**
+	 * Alert the user that client side validation has failed.
+	*/
+	invalid: PropTypes.bool.isRequired,
+
 	/**
 	 * Boolean that determines whether component is a `textarea` or `input` tag.
 	 */

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -46,10 +46,14 @@
 		border-color: color-scheme.$accent;
 	}
 
+	&:invalid,
+	&[aria-invalid=true] {
+		border-color: tokens.$color-red;
+	}
+
 	&[disabled],
 	&[readonly] {
 		background-color: transparent;
-		// color: color-scheme.$typography-faint;
 		color: tokens.$color-red;
 
 		&:hover {
@@ -73,4 +77,15 @@
 .input::-webkit-credentials-auto-fill-button {
 	/* moves the key icon in Safari outside our login fields */
 	margin-right: -24px;
+}
+
+.hint {
+	@include fonts.maison-500-1;
+
+	color: color-scheme.$typography-faint;
+	margin-top: 4px;
+
+	&.invalid {
+		color: tokens.$color-red;
+	}
 }

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -9,6 +9,7 @@
 
 	display: block;
 	line-height: 1.25;
+	margin: 8px 0;
 
 	&.required {
 		display: flex;
@@ -33,7 +34,6 @@
 	border-radius: tokens.$size-border-radius;
 	color: inherit;
 	font-size: 16px;
-	margin: 8px 0;
 	transition: border-color, 0.25s;
 	width: 100%;
 
@@ -46,7 +46,6 @@
 		border-color: color-scheme.$accent;
 	}
 
-	&:invalid,
 	&[aria-invalid=true] {
 		border-color: tokens.$color-red;
 	}

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -75,6 +75,24 @@ Sample component with password type, which automatically obscures user input.
 	</Story>
 </Canvas>
 
+Sample component with hint and validation override.
+<Canvas>
+	<Story
+		args={{
+			...defaultActions,
+			id: 'promo-code',
+			label: 'Promo code',
+			placeholder: 'Promo code',
+			invalid: true,
+			hint: 'Not a valid promo code',
+			type: 'text',
+		}}
+		name="Invalid"
+	>
+		{args => <TextInput {...args} />}
+	</Story>
+</Canvas>
+
 Sample multiline TextInput that could be used for (e.g.) feedback forms.
 <Canvas>
 	<Story
@@ -82,6 +100,7 @@ Sample multiline TextInput that could be used for (e.g.) feedback forms.
 			...defaultActions,
 			id: 'textarea',
 			label: 'Message',
+			hint: 'We welcome as much feedback as you’d like to give.',
 			isMultiline: true,
 		}}
 		name="TextArea"


### PR DESCRIPTION
Together these allow us to display a custom error (e.g. from server-side validation).