### PR TITLE
Hint should be optional

### DIFF
--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -77,9 +77,9 @@ const TextInput = ( {
 				required={required}
 			/>
 		}
-		<div className={cx( 'hint', { invalid } )}>
+		{hint && <div className={cx( 'hint', { invalid } )}>
 			{hint}
-		</div>
+		</div>}
 	</label>
 );
 


### PR DESCRIPTION
Conditionally display the `hint` element. If `hint` is not present its margin shouldn't be either.