### PR TITLE
Add value to TextInput

### DIFF
--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -116,7 +116,7 @@ TextInput.propTypes = {
 	/**
 	 * Descriptive content displayed under the element, usually to provide context or instructions to the user (e.g. 'Password must be at least 6 characters' )
 	 */
-	hint: PropTypes.node.isRequired,
+	hint: PropTypes.node,
 	/**
 	 * HTML ID of the component. Forwarded to the input/textarea element.
 	 */

--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -26,6 +26,7 @@ const TextInput = ( {
 	readOnly,
 	required,
 	type,
+	value,
 } ) => (
 	<label className={styles.container}>
 		{label && (
@@ -33,6 +34,7 @@ const TextInput = ( {
 				{label}
 			</span>
 		)}
+
 		{isMultiline &&
 			<textarea
 				className={styles.textarea}
@@ -51,6 +53,7 @@ const TextInput = ( {
 				readOnly={readOnly}
 				ref={inputRef}
 				required={required}
+				value={value}
 			/>
 		}
 
@@ -75,8 +78,10 @@ const TextInput = ( {
 				readOnly={readOnly}
 				ref={inputRef}
 				required={required}
+				value={value}
 			/>
 		}
+
 		{hint && <div className={cx( 'hint', { invalid } )}>
 			{hint}
 		</div>}
@@ -190,6 +195,9 @@ TextInput.propTypes = {
 		'url',
 		'datetime',
 	] ).isRequired,
+
+	// If present, the value of the form field.
+	value: PropTypes.string,
 };
 
 TextInput.defaultProps = {

--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -203,7 +203,7 @@ TextInput.propTypes = {
 };
 
 TextInput.defaultProps = {
-	autoComplete: true,
+	autoComplete: 'on',
 	disabled: false,
 	isMultiline: false,
 	onBlur: () => null,

--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -196,7 +196,9 @@ TextInput.propTypes = {
 		'datetime',
 	] ).isRequired,
 
-	// If present, the value of the form field.
+	/**
+	 *  If present, the value of the form field.
+	 */
 	value: PropTypes.string,
 };
 

--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -126,10 +126,9 @@ TextInput.propTypes = {
 	 */
 	inputRef: PropTypes.object,
 	/**
-	 * Alert the user that client side validation has failed.
+	 * Alert the user that validation has failed. This may be useful where HTML5 validation is not sufficient (for example, a field that is validated server side)
 	*/
 	invalid: PropTypes.bool.isRequired,
-
 	/**
 	 * Boolean that determines whether component is a `textarea` or `input` tag.
 	 */
@@ -205,6 +204,7 @@ TextInput.propTypes = {
 TextInput.defaultProps = {
 	autoComplete: 'on',
 	disabled: false,
+	invalid: false,
 	isMultiline: false,
 	onBlur: () => null,
 	onChange: () => null,


### PR DESCRIPTION
This gives us the option to use it as a controlled field.

While we currently prefer uncontrolled fields on qz.com, some situations call for controlled fields. An example is the PromoCodeField, which is both prefilled and reset by other controls.