### PR TITLE
Dark mode alternate background

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2242,8 +2242,8 @@
 			}
 		},
 		"@quartz/styles": {
-			"version": "github:Quartz/styles#aa7b8c05c45e92e791096aa0a34989e1aed8af49",
-			"from": "github:Quartz/styles#aa7b8c0",
+			"version": "github:Quartz/styles#7528fdedaa8801d9727ecbf6a9d1c6a101bb6d21",
+			"from": "github:Quartz/styles#0.2.0",
 			"dev": true,
 			"requires": {
 				"normalize.css": "^8.0.1"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@quartz/eslint-config-react": "^1.1.3",
 		"@quartz/js-utils": "^1.1.1",
 		"@quartz/stylelint-config": "^1.2.0",
-		"@quartz/styles": "github:Quartz/styles#aa7b8c0",
+		"@quartz/styles": "github:Quartz/styles#0.2.0",
 		"@storybook/addon-a11y": "^6.0.10",
 		"@storybook/addon-essentials": "^6.0.10",
 		"@storybook/addon-links": "^6.0.10",

--- a/src/components/ColorScheme/ColorScheme.tsx
+++ b/src/components/ColorScheme/ColorScheme.tsx
@@ -46,7 +46,7 @@ export const schemes = {
 	DARK: {
 		accent: color[ 'accent-blue-dark' ].value,
 		background1: color[ 'dark-blue' ].value,
-		background2: color[ 'dark-blue' ].value,
+		background2: color[ 'mid-dark-blue' ].value,
 		highlight: createRgba( ...hexToRGB( color.pink.value ), 0.25 ),
 		typography: color.white.value,
 	},


### PR DESCRIPTION
Distinguishes `background-1` and `background-2`, currently the same color, by using the new `mid-dark-blue` color for `background-2`. We need this to give the essentials section a distinct background from the article section above it.
