### PR TITLE
Adjusts BadgeGroup props

### DIFF
--- a/src/components/BadgeGroup/BadgeGroup.jsx
+++ b/src/components/BadgeGroup/BadgeGroup.jsx
@@ -5,6 +5,7 @@ import TextGroup from '../TextGroup/TextGroup';
 import styles from './BadgeGroup.scss';
 
 function BadgeGroup ( {
+	centered,
 	imageUrl,
 	kicker,
 	size,
@@ -12,7 +13,7 @@ function BadgeGroup ( {
 	title,
 } ) {
 	return (
-		<div className={styles.container}>
+		<div className={`${styles.container} ${centered ? styles.centered : ''}`}>
 			{
 				imageUrl &&
 					<div className={styles.badge}>
@@ -40,6 +41,12 @@ function BadgeGroup ( {
 
 BadgeGroup.propTypes = {
 	/**
+	 * Style prop. Sets whether or not the component is center aligned or (default)
+	 * top-aligned. Useful if no tagline exists.
+	 */
+	centered: PropTypes.bool,
+
+	/**
 	 * The image URL. Any existing query parameters are stripped and it will be
 	 * resized and cropped automatically. Note that an image URL is not required,
 	 * mainly because some content represented may not have an associated image.
@@ -56,7 +63,7 @@ BadgeGroup.propTypes = {
 	 * Size preset. Adjusts the size of the TextGroup (see
 	 * `TextGroup.propTypes.size`).
 	 */
-	size: PropTypes.oneOf( [ 'small', 'medium' ] ),
+	size: PropTypes.oneOf( [ 'small', 'medium', 'large' ] ),
 
 	/**
 	 * Tagline to appear beneath the title.

--- a/src/components/BadgeGroup/BadgeGroup.jsx
+++ b/src/components/BadgeGroup/BadgeGroup.jsx
@@ -5,7 +5,6 @@ import TextGroup from '../TextGroup/TextGroup';
 import styles from './BadgeGroup.scss';
 
 function BadgeGroup ( {
-	centered,
 	imageUrl,
 	kicker,
 	size,
@@ -13,7 +12,7 @@ function BadgeGroup ( {
 	title,
 } ) {
 	return (
-		<div className={`${styles.container} ${centered ? styles.centered : ''}`}>
+		<div className={styles.container}>
 			{
 				imageUrl &&
 					<div className={styles.badge}>
@@ -40,12 +39,6 @@ function BadgeGroup ( {
 }
 
 BadgeGroup.propTypes = {
-	/**
-	 * Style prop. Sets whether or not the component is center aligned or (default)
-	 * top-aligned. Useful if no tagline exists.
-	 */
-	centered: PropTypes.bool,
-
 	/**
 	 * The image URL. Any existing query parameters are stripped and it will be
 	 * resized and cropped automatically. Note that an image URL is not required,

--- a/src/components/BadgeGroup/BadgeGroup.scss
+++ b/src/components/BadgeGroup/BadgeGroup.scss
@@ -6,6 +6,10 @@
 	flex-direction: row;
 }
 
+.centered {
+	align-items: center;
+}
+
 .badge {
 	margin-right: 10px;
 }

--- a/src/components/BadgeGroup/BadgeGroup.scss
+++ b/src/components/BadgeGroup/BadgeGroup.scss
@@ -11,10 +11,8 @@
 }
 
 .text {
-	display: flex;
+	align-self: center;
 	flex-grow: 1;
-	flex-direction: column;
-	justify-content: center;
 }
 
 .arrow {

--- a/src/components/BadgeGroup/BadgeGroup.scss
+++ b/src/components/BadgeGroup/BadgeGroup.scss
@@ -1,13 +1,9 @@
 @use '~@quartz/styles/scss/color-scheme';
 
 .container {
-	align-items: start;
+	align-items: stretch;
 	display: flex;
 	flex-direction: row;
-}
-
-.centered {
-	align-items: center;
 }
 
 .badge {
@@ -15,7 +11,10 @@
 }
 
 .text {
+	display: flex;
 	flex-grow: 1;
+	flex-direction: column;
+	justify-content: center;
 }
 
 .arrow {


### PR DESCRIPTION
BadgeGroup tagline is optional, but the component is top-aligned, which can look a little off (see, e.g. Inbox titles on https://qz.comemails/quartz-japan/ ); adds a prop to BadgeGroup to allow for centered text in that instance. Also enables "large" TextGroups to fix an error on same page.