### PR TITLE
Enforce active and inactive tab colors for links

### DIFF
--- a/src/components/TabNav/TabNav.scss
+++ b/src/components/TabNav/TabNav.scss
@@ -66,5 +66,13 @@
 	&[aria-current="true"] {
 		border-bottom: 2px solid color-scheme.$accent;
 		color: color-scheme.$accent;
+
+		a {
+			color: color-scheme.$accent;
+		}
+	}
+
+	a {
+		color: inherit;
 	}
 }

--- a/src/components/TabNav/TabNav.stories.mdx
+++ b/src/components/TabNav/TabNav.stories.mdx
@@ -37,16 +37,16 @@ A link (`<a>`) or button (`<button>`) element should be passed into each TabNavI
 		{args => (
 			<TabNav>
 				<TabNavItem isActive={true}>
-					<a style={{color: 'inherit'}} href="#">John</a>
+					<a href="#">John</a>
 				</TabNavItem>
 				<TabNavItem>
-					<a style={{color: 'inherit'}} href="#">Paul</a>
+					<a href="#">Paul</a>
 				</TabNavItem>
 				<TabNavItem>
-					<a style={{color: 'inherit'}} href="#">George</a>
+					<a href="#">George</a>
 				</TabNavItem>
 				<TabNavItem>
-					<a style={{color: 'inherit'}} href="#">Ringo</a>
+					<a href="#">Ringo</a>
 				</TabNavItem>
 			</TabNav>
 		)}


### PR DESCRIPTION
Links often have their own color styling. If TabNav has opinions about what the active and inactive colors are, they should probably be enforced.

This avoids the need for boilerplate tab-link classes that apply `color: inherit`. The color can of course still be overridden if need be, but it seems like Prism should provide a default that "just works."

Otherwise I'd recommend removing the color styles entirely and make that something the implementor always needs to do themselves.

