### PR TITLE
Adds Image and ResponsiveImage className prop

### DIFF
--- a/src/components/Image/Image.jsx
+++ b/src/components/Image/Image.jsx
@@ -4,6 +4,7 @@ import styles from './Image.scss';
 
 function ImageAmp ( {
 	alt,
+	className,
 	height,
 	sizes,
 	src,
@@ -14,6 +15,7 @@ function ImageAmp ( {
 	return (
 		<amp-img
 			alt={alt}
+			className={className}
 			height="1"
 			layout="responsive"
 			sizes={sizes}
@@ -27,6 +29,7 @@ function ImageAmp ( {
 
 ImageAmp.propTypes = {
 	alt: PropTypes.string.isRequired,
+	className: PropTypes.string,
 	height: PropTypes.number.isRequired,
 	sizes: PropTypes.string,
 	src: PropTypes.string.isRequired,
@@ -38,6 +41,7 @@ ImageAmp.propTypes = {
 function Image ( {
 	alt,
 	amp,
+	className,
 	fallbackHeight: height,
 	fallbackWidth: width,
 	loading,
@@ -46,10 +50,13 @@ function Image ( {
 	srcSet,
 	title,
 } ) {
+	const classes = `${styles.image} ${className}`;
+
 	if ( amp ) {
 		return (
 			<ImageAmp
 				alt={alt}
+				className={classes}
 				height={1}
 				sizes={sizes}
 				src={src}
@@ -63,7 +70,7 @@ function Image ( {
 	return (
 		<img
 			alt={alt}
-			className={styles.image}
+			className={classes}
 			decoding="async"
 			height={height}
 			loading={loading}
@@ -89,6 +96,11 @@ Image.propTypes = {
 	 * https://amp.dev/documentation/components/amp-img/
 	 */
 	amp: PropTypes.bool.isRequired,
+
+	/**
+		* Passed verbatim to element as class attribute.
+		*/
+	className: PropTypes.string,
 
 	/**
 	 * The rendered height of the image when CSS cannot be loaded or in very old

--- a/src/components/Image/Image.jsx
+++ b/src/components/Image/Image.jsx
@@ -4,7 +4,6 @@ import styles from './Image.scss';
 
 function ImageAmp ( {
 	alt,
-	className,
 	height,
 	sizes,
 	src,
@@ -15,7 +14,6 @@ function ImageAmp ( {
 	return (
 		<amp-img
 			alt={alt}
-			className={className}
 			height="1"
 			layout="responsive"
 			sizes={sizes}
@@ -29,7 +27,6 @@ function ImageAmp ( {
 
 ImageAmp.propTypes = {
 	alt: PropTypes.string.isRequired,
-	className: PropTypes.string,
 	height: PropTypes.number.isRequired,
 	sizes: PropTypes.string,
 	src: PropTypes.string.isRequired,
@@ -50,13 +47,10 @@ function Image ( {
 	srcSet,
 	title,
 } ) {
-	const classes = `${styles.image} ${className}`;
-
 	if ( amp ) {
 		return (
 			<ImageAmp
 				alt={alt}
-				className={classes}
 				height={1}
 				sizes={sizes}
 				src={src}
@@ -70,7 +64,7 @@ function Image ( {
 	return (
 		<img
 			alt={alt}
-			className={classes}
+			className={className ? `${styles.image} ${className}` : styles.image}
 			decoding="async"
 			height={height}
 			loading={loading}

--- a/src/components/Image/Image.jsx
+++ b/src/components/Image/Image.jsx
@@ -98,8 +98,8 @@ Image.propTypes = {
 	amp: PropTypes.bool.isRequired,
 
 	/**
-		* Passed verbatim to element as class attribute.
-		*/
+	 * Passed verbatim to element as class attribute.
+	 */
 	className: PropTypes.string,
 
 	/**

--- a/src/components/Image/Image.stories.mdx
+++ b/src/components/Image/Image.stories.mdx
@@ -11,7 +11,7 @@ This component does not provide [art direction](https://developer.mozilla.org/en
 
 ## Usage guidelines
 
-- **Do** use a container to constrain the size or shape of the image. An `Image` will always expand or contract to fit the width of its container. The `Image` component purposefully does not accept a `className` prop.
+- **Do** use a container to constrain the size or shape of the image whenever possible. By default, an `Image` will expand or contract to fit the width of its container. This can be overridden using styles applied via the `className` prop.
 - **Do** understand that the `fallbackHeight` and `fallbackWidth` props are [used to set aspect ratio and help the browser reserve space](https://blog.logrocket.com/jank-free-page-loading-with-media-aspect-ratios/) for the image during initial layout.
 - **Do** [provide useful alt text](https://www.w3.org/WAI/tutorials/images/decision-tree/) for your images. Sometimes, an empty string is the most useful!
 - **Do** learn why and how to use [responsive rendering](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images). It’s important to understand how `sizes` and `srcSet` work.

--- a/src/components/Image/Image.stories.mdx
+++ b/src/components/Image/Image.stories.mdx
@@ -7,7 +7,7 @@ import Image from './Image';
 
 Displays an image. The `Image` component requires `fallbackHeight` and `fallbackWidth` to set aspect ratio and `sizes` and `srcSet` to provide [responsive rendering](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images). They will not be calculated for you and there are no default values. Future components may provide a simpler implementation for specific use cases.
 
-The image element is rendered with some lightly opinionated but commonly needed styles: `display: block` and `width: 100%`. These styles can be overridden using the `className` prop.
+The image element (`img` or `amp-img`) is rendered with some lightly opinionated but commonly needed styles: `display: block` and `width: 100%`. These styles may be overridden using the `className` prop, but whenever possible you should use a parent element to constrain the dimensions of the image.
 
 This component does not provide [art direction](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture), which is also a task for a future component.
 

--- a/src/components/Image/Image.stories.mdx
+++ b/src/components/Image/Image.stories.mdx
@@ -7,11 +7,13 @@ import Image from './Image';
 
 Displays an image. The `Image` component requires `fallbackHeight` and `fallbackWidth` to set aspect ratio and `sizes` and `srcSet` to provide [responsive rendering](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images). They will not be calculated for you and there are no default values. Future components may provide a simpler implementation for specific use cases.
 
+The image element is rendered with some lightly opinionated but commonly needed styles: `display: block` and `width: 100%`. These styles can be overridden using the `className` prop.
+
 This component does not provide [art direction](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture), which is also a task for a future component.
 
 ## Usage guidelines
 
-- **Do** use a container to constrain the size or shape of the image whenever possible. By default, an `Image` will expand or contract to fit the width of its container. This can be overridden using styles applied via the `className` prop.
+- **Do** use a container to constrain the size or shape of the image whenever possible. By default, an `Image` will expand or contract to fit the width of its container. This can be overridden using styles applied via the `className` prop. You may (rarely) want to do this in order to have an image fill its parent element by height rather than width, or in order to use the `object-fit` property.
 - **Do** understand that the `fallbackHeight` and `fallbackWidth` props are [used to set aspect ratio and help the browser reserve space](https://blog.logrocket.com/jank-free-page-loading-with-media-aspect-ratios/) for the image during initial layout.
 - **Do** [provide useful alt text](https://www.w3.org/WAI/tutorials/images/decision-tree/) for your images. Sometimes, an empty string is the most useful!
 - **Do** learn why and how to use [responsive rendering](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images). It’s important to understand how `sizes` and `srcSet` work.

--- a/src/components/ResponsiveImage/ResponsiveImage.jsx
+++ b/src/components/ResponsiveImage/ResponsiveImage.jsx
@@ -6,6 +6,7 @@ import { arrayFromRange, resizeWPImage } from '@quartz/js-utils';
 function ResponsiveImage( {
 	alt,
 	amp,
+	className,
 	fallbackHeight,
 	fallbackWidth,
 	sizes,
@@ -33,6 +34,7 @@ function ResponsiveImage( {
 		<Image
 			alt={alt}
 			amp={amp}
+			className={className}
 			sizes={sizes || sizesDefault}
 			src={resizeWPImage( src, fallbackWidth, fallbackHeight )}
 			srcSet={srcSet}
@@ -55,6 +57,11 @@ ResponsiveImage.propTypes = {
 	 * https://amp.dev/documentation/components/amp-img/
 	 */
 	amp: PropTypes.bool.isRequired,
+
+	/**
+		* Passed verbatim to img or amp-img element as class attribute.
+		*/
+	className: PropTypes.string,
 
 	/**
 	 * The rendered height of the image when CSS cannot be loaded or in very old

--- a/src/components/ResponsiveImage/ResponsiveImage.jsx
+++ b/src/components/ResponsiveImage/ResponsiveImage.jsx
@@ -59,8 +59,8 @@ ResponsiveImage.propTypes = {
 	amp: PropTypes.bool.isRequired,
 
 	/**
-		* Passed verbatim to img or amp-img element as class attribute.
-		*/
+	 * Passed verbatim to img or amp-img element as class attribute.
+	 */
 	className: PropTypes.string,
 
 	/**


### PR DESCRIPTION
I've reluctantly concluded that we need to offer a `className` prop for image components. Although we include some styles with `Image` that are enough for most cases, we sometimes need to either override these styles, e.g. in order to have the image fit its parent by height (`height: 100%; width: auto`) or to apply styles that only work on the image element itself, e.g. `object-fit`.

I still want to encourage constraining image dimensions using a parent whenever possible, so I've updated the docs to reflect this.