### PR TITLE
Fix module import

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"dist/**/*",
 		"src/**/*"
 	],
-	"module": "src/components/index",
+	"main": "src/components/index",
 	"types": "dist/index.d.ts",
 	"dependencies": {},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"src/**/*"
 	],
 	"main": "src/components/index",
+	"module": "src/components/index",
 	"types": "dist/index.d.ts",
 	"dependencies": {},
 	"devDependencies": {


### PR DESCRIPTION
The `module` directive works for bundlers like Webpack but not for non-bundling tools like TypeScript and ESLint. Provide both `main` and `module`.

Eventually we may want to point `main` to a "compiled" version of Prism, but we've decided to forego that for now since there isn't a use case for it yet.