### PR TITLE
Group components by type

### DIFF
--- a/src/components/ArticleStrip/ArticleStrip.stories.mdx
+++ b/src/components/ArticleStrip/ArticleStrip.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Story } from '@storybook/addon-docs/blocks';
 import ArticleStrip from './ArticleStrip';
 
-<Meta title="ArticleStrip" component={ArticleStrip} />
+<Meta title="Content/ArticleStrip" component={ArticleStrip} />
 
 # ArticleStrip
 

--- a/src/components/Badge/Badge.stories.mdx
+++ b/src/components/Badge/Badge.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Story } from '@storybook/addon-docs/blocks';
 import Badge from './Badge';
 
-<Meta title="Badge" component={Badge} />
+<Meta title="Content/Badge" component={Badge} />
 
 # Badge
 

--- a/src/components/BadgeGroup/BadgeGroup.stories.mdx
+++ b/src/components/BadgeGroup/BadgeGroup.stories.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Canvas, Story } from '@storybook/addon-docs/blocks';
 import LinkTo from '@storybook/addon-links/react';
 import BadgeGroup from './BadgeGroup';
 
-<Meta title="BadgeGroup" component={BadgeGroup} />
+<Meta title="Content/BadgeGroup" component={BadgeGroup} />
 
 # BadgeGroup
 

--- a/src/components/Blockquote/Blockquote.stories.mdx
+++ b/src/components/Blockquote/Blockquote.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Props, Story } from '@storybook/addon-docs/blocks';
 import Blockquote from './Blockquote';
 
-<Meta title="Blockquote" component={Blockquote} />
+<Meta title="Content/Blockquote" component={Blockquote} />
 
 # Blockquote
 

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Story } from '@storybook/addon-docs/blocks';
 import Button, { ButtonLabel } from './Button';
 
-<Meta title="Button" component={Button} />
+<Meta title="Forms/Button" component={Button} />
 
 # Button
 

--- a/src/components/CalloutCard/CalloutCard.stories.mdx
+++ b/src/components/CalloutCard/CalloutCard.stories.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import CalloutCard from './CalloutCard';
 import TextGroup from '../TextGroup/TextGroup';
 
-<Meta title="CalloutCard" component={CalloutCard} />
+<Meta title="Layout/CalloutCard" component={CalloutCard} />
 
 # Callout Card
 

--- a/src/components/Checkbox/Checkbox.stories.mdx
+++ b/src/components/Checkbox/Checkbox.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import Checkbox from './Checkbox';
 
-<Meta title="Checkbox" component={Checkbox} />
+<Meta title="Forms/Checkbox" component={Checkbox} />
 
 # Checkbox
 

--- a/src/components/ColorScheme/ColorScheme.stories.mdx
+++ b/src/components/ColorScheme/ColorScheme.stories.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import Button from '../Button/Button';
 import ColorScheme, { schemes } from './ColorScheme';
 
-<Meta title="ColorScheme" component={ColorScheme} />
+<Meta title="UI/ColorScheme" component={ColorScheme} />
 
 # ColorScheme
 

--- a/src/components/EmojiList/EmojiList.stories.mdx
+++ b/src/components/EmojiList/EmojiList.stories.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import EmojiList from './EmojiList';
 import CalloutCard from '../CalloutCard/CalloutCard';
 
-<Meta title="EmojiList" component={EmojiList} />
+<Meta title="Content/EmojiList" component={EmojiList} />
 
 # EmojiList
 

--- a/src/components/Example/Example.stories.mdx
+++ b/src/components/Example/Example.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Story } from '@storybook/addon-docs/blocks';
 import Example from './Example';
 
-<Meta title="Example" component={Example} />
+<Meta title="Examples/Example" component={Example} />
 
 # Example
 

--- a/src/components/FormLabel/FormLabel.stories.mdx
+++ b/src/components/FormLabel/FormLabel.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Story } from '@storybook/addon-docs/blocks';
 import FormLabel from './FormLabel';
 
-<Meta title="FormLabel" component={FormLabel} />
+<Meta title="Forms/FormLabel" component={FormLabel} />
 
 # FormLabel
 

--- a/src/components/Hed/Hed.stories.mdx
+++ b/src/components/Hed/Hed.stories.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import LinkTo from '@storybook/addon-links/react';
 import Hed from './Hed';
 
-<Meta title="Hed" component={Hed} />
+<Meta title="Content/Hed" component={Hed} />
 
 
 # Hed

--- a/src/components/Image/Image.stories.mdx
+++ b/src/components/Image/Image.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import Image from './Image';
 
-<Meta title="Image" component={Image} />
+<Meta title="Content/Image" component={Image} />
 
 # Image
 

--- a/src/components/Kicker/Kicker.stories.mdx
+++ b/src/components/Kicker/Kicker.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import Kicker from './Kicker';
 
-<Meta title="Kicker" component={Kicker} />
+<Meta title="Content/Kicker" component={Kicker} />
 
 # Kicker
 

--- a/src/components/PageHeader/PageHeader.stories.mdx
+++ b/src/components/PageHeader/PageHeader.stories.mdx
@@ -2,7 +2,7 @@ import { Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 import PageHeader from './PageHeader.jsx';
 import { TabNav, TabNavItem } from '../TabNav/TabNav';
 
-<Meta title="PageHeader" component={PageHeader} />
+<Meta title="Layout/PageHeader" component={PageHeader} />
 
 # PageHeader
 

--- a/src/components/Pill/Pill.stories.mdx
+++ b/src/components/Pill/Pill.stories.mdx
@@ -3,7 +3,7 @@ import Hed from '../Hed/Hed';
 import Pill from './Pill';
 import { TabNav, TabNavItem } from '../TabNav/TabNav';
 
-<Meta title="Pill" component={Pill} />
+<Meta title="Content/Pill" component={Pill} />
 
 # Pill
 

--- a/src/components/RadioButton/RadioButton.stories.mdx
+++ b/src/components/RadioButton/RadioButton.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import RadioButton from './RadioButton';
 
-<Meta title="RadioButton" component={RadioButton} />
+<Meta title="Forms/RadioButton" component={RadioButton} />
 
 # RadioButton
 

--- a/src/components/ResponsiveImage/ResponsiveImage.stories.mdx
+++ b/src/components/ResponsiveImage/ResponsiveImage.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import ResponsiveImage from './ResponsiveImage';
 
-<Meta title="ResponsiveImage" component={ResponsiveImage} />
+<Meta title="Content/ResponsiveImage" component={ResponsiveImage} />
 
 # ResponsiveImage
 

--- a/src/components/Select/Select.stories.mdx
+++ b/src/components/Select/Select.stories.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Canvas, Story } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
 import Select from './Select';
 
-<Meta title="Select" component={Select} />
+<Meta title="Forms/Select" component={Select} />
 
 export const options = [
 	{ label: 'Future of Finance', value: 'ff' },

--- a/src/components/Spinner/Spinner.stories.mdx
+++ b/src/components/Spinner/Spinner.stories.mdx
@@ -1,7 +1,7 @@
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import Spinner from './Spinner';
 
-<Meta title="Spinner" component={Spinner} />
+<Meta title="UI/Spinner" component={Spinner} />
 
 # Spinner
 

--- a/src/components/TabNav/TabNav.stories.mdx
+++ b/src/components/TabNav/TabNav.stories.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Canvas, Props, Story } from '@storybook/addon-docs/blocks';
 import LinkTo from '@storybook/addon-links/react';
 import { TabNav, TabNavItem } from './TabNav';
 
-<Meta title="TabNav" component={TabNav} />
+<Meta title="Layout/TabNav" component={TabNav} />
 
 # TabNav and TabNavItem
 

--- a/src/components/Tagline/Tagline.stories.mdx
+++ b/src/components/Tagline/Tagline.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import Tagline from './Tagline';
 
-<Meta title="Tagline" component={Tagline} />
+<Meta title="Content/Tagline" component={Tagline} />
 
 # Tagline
 

--- a/src/components/TextGroup/TextGroup.stories.mdx
+++ b/src/components/TextGroup/TextGroup.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import TextGroup from './TextGroup';
 
-<Meta title="TextGroup" component={TextGroup} />
+<Meta title="Content/TextGroup" component={TextGroup} />
 
 # TextGroup
 

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions';
 import LinkTo from '@storybook/addon-links/react';
 import { TextInput } from './TextInput';
 
-<Meta title="TextInput" component={TextInput} />
+<Meta title="Forms/TextInput" component={TextInput} />
 
 # TextInput
 

--- a/src/components/TextInput/TextMultilineInput.stories.mdx
+++ b/src/components/TextInput/TextMultilineInput.stories.mdx
@@ -2,7 +2,7 @@ import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 import { action } from '@storybook/addon-actions';
 import { TextMultilineInput } from './TextInput';
 
-<Meta title="TextMultilineInput" component={TextMultilineInput} />
+<Meta title="Forms/TextMultilineInput" component={TextMultilineInput} />
 
 # TextMultilineInput
 


### PR DESCRIPTION
Storybook allows us to group components by type. These are just suggestions and I'm sure we'll reorganize over time. This could relieve a little bit of the naming pressure, since components can take some context from the group they're in.

<img width="205" alt="Screen Shot 2020-12-18 at 9 46 10 AM" src="https://user-images.githubusercontent.com/739304/102627358-173ea700-4116-11eb-9589-dec4220432ce.png">