### PR TITLE
Set default font for Prism to Maison

### DIFF
--- a/.storybook/styles/global.scss
+++ b/.storybook/styles/global.scss
@@ -1,10 +1,11 @@
 @use '~@quartz/styles/scss/base';
+@use '~@quartz/styles/scss/fonts';
 
-// This rule doesn't seem to do much, but is important to prevent Storybook from
-// throwing out unused styles *in production*. Not sure why this is the case;
-// might be a (very annoying) bug.
+// Having at least one used class from this file is important to prevent
+// Storybook from throwing out unused styles *in production*. Not sure why this
+// is the case; might be a (very annoying) bug.
 .main {
-	display: block;
+	@include fonts.maison;
 }
 
 @font-face {

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -1,5 +1,4 @@
 @use '~@quartz/styles/scss/color-scheme';
-@use '~@quartz/styles/scss/fonts';
 @use '~@quartz/styles/scss/helpers/positioning';
 @use '~@quartz/styles/scss/helpers/resets';
 @use '~@quartz/styles/scss/states';
@@ -34,8 +33,6 @@
 }
 
 .label {
-	@include fonts.maison;
-
 	font-size: 16px;
 	opacity: inherit;
 	white-space: nowrap;

--- a/src/components/Checkbox/Checkbox.scss
+++ b/src/components/Checkbox/Checkbox.scss
@@ -1,12 +1,9 @@
 @use '~@quartz/styles/scss/borders';
 @use '~@quartz/styles/scss/color-scheme';
-@use '~@quartz/styles/scss/fonts';
 @use '~@quartz/styles/scss/helpers/resets';
 @use '~@quartz/styles/scss/tokens';
 
 .container {
-	@include fonts.maison;
-
 	cursor: pointer;
 	display: flex;
 }

--- a/src/components/RadioButton/RadioButton.scss
+++ b/src/components/RadioButton/RadioButton.scss
@@ -1,13 +1,10 @@
 @use '~@quartz/styles/scss/borders';
 @use '~@quartz/styles/scss/color-scheme';
-@use '~@quartz/styles/scss/fonts';
 @use '~@quartz/styles/scss/helpers/positioning';
 @use '~@quartz/styles/scss/helpers/resets';
 @use '~@quartz/styles/scss/tokens';
 
 .container {
-	@include fonts.maison;
-
 	display: inline-flex;
 	align-items: center;
 	cursor: pointer;

--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -1,13 +1,10 @@
 @use '~@quartz/styles/scss/borders';
 @use '~@quartz/styles/scss/color-scheme';
-@use '~@quartz/styles/scss/fonts';
 @use '~@quartz/styles/scss/helpers/positioning';
 @use '~@quartz/styles/scss/helpers/resets';
 @use '~@quartz/styles/scss/tokens';
 
 .container {
-	@include fonts.maison;
-
 	display: block;
 }
 

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -7,7 +7,6 @@
 .input,
 .textarea {
 	@include resets.text-input;
-	@include fonts.maison;
 
 	background-color: color-scheme.$background-2;
 	border: borders.$solid-interactive;


### PR DESCRIPTION
Mirror our change to `qz-react`, which allows Prism to also remove needless `@include fonts.maison` boilerplate.