### PR TITLE
Constrain layout component

### DIFF
--- a/dist/Constrain/Constrain.d.ts
+++ b/dist/Constrain/Constrain.d.ts
@@ -1,0 +1,12 @@
+import React from 'react';
+export default function Constrain(props: {
+    /**
+     * Children that will be constrained by the container.
+     */
+    children: React.ReactNode;
+    /**
+     * The size of the constrained container.
+     */
+    size: 'small' | 'medium' | 'large' | 'extra-large';
+}): JSX.Element;
+//# sourceMappingURL=Constrain.d.ts.map

--- a/dist/Constrain/Constrain.d.ts.map
+++ b/dist/Constrain/Constrain.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"Constrain.d.ts","sourceRoot":"","sources":["../../src/components/Constrain/Constrain.tsx"],"names":[],"mappings":"AAAA,OAAO,KAAK,MAAM,OAAO,CAAC;AAG1B,MAAM,CAAC,OAAO,UAAU,SAAS,CAAG,KAAK,EAAE;IAC1C;;OAEG;IACH,QAAQ,EAAE,KAAK,CAAC,SAAS,CAAC;IAE1B;;OAEG;IACH,IAAI,EAAE,OAAO,GAAG,QAAQ,GAAG,OAAO,GAAG,aAAa,CAAC;CACnD,eAMA"}

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -4,6 +4,7 @@ export { default as BadgeGroup } from "./BadgeGroup/BadgeGroup";
 export { default as Blockquote } from "./Blockquote/Blockquote";
 export { default as CalloutCard } from "./CalloutCard/CalloutCard";
 export { default as Checkbox } from "./Checkbox/Checkbox";
+export { default as Constrain } from "./Constrain/Constrain";
 export { default as EmojiList } from "./EmojiList/EmojiList";
 export { default as FormLabel } from "./FormLabel/FormLabel";
 export { default as Hed } from "./Hed/Hed";

--- a/src/components/Constrain/Constrain.scss
+++ b/src/components/Constrain/Constrain.scss
@@ -1,0 +1,31 @@
+@use '~@quartz/styles/scss/media-queries';
+@use '~@quartz/styles/scss/tokens';
+
+.container {
+	margin: auto;
+	padding: 0 tokens.$size-gutter-mobile;
+
+	@include media-queries.tablet-portrait-up {
+		padding: 0 tokens.$size-gutter-tablet;
+	}
+
+	@include media-queries.desktop-up {
+		padding: 0 tokens.$size-gutter-desktop;
+	}
+}
+
+.small {
+	max-width: 620px; // corresponds to $max-width-content-article
+}
+
+.medium {
+	max-width: 940px; // corresponds to $max-width-content
+}
+
+.large {
+	max-width: tokens.$size-breakpoint-desktop;
+}
+
+.extra-large {
+	max-width: tokens.$size-breakpoint-desktop-large;
+}

--- a/src/components/Constrain/Constrain.stories.mdx
+++ b/src/components/Constrain/Constrain.stories.mdx
@@ -1,0 +1,78 @@
+import { ArgsTable, Canvas, Story } from '@storybook/addon-docs/blocks';
+import { action } from '@storybook/addon-actions';
+import Constrain from './Constrain';
+
+<Meta title="Layout/Constrain" component={Constrain} />
+
+# Constrain
+
+A layout container that provides a centering, max-width, and breakpoint-
+appropriate gutters.
+
+## Props
+
+export const defaultChildren = (
+	<>
+		<p>Reflecting on Wikipedia’s most-read pages is like holding up an encyclopedic mirror to 2020. English speakers read about those that died, about American politics and political institutions, about the stories behind popular TV shows, and about coronavirus.</p>
+		<p>Readers in June sought information on the Black experience in America and beyond—the death of George Floyd and Breonna Taylor, Edward Colston, and Juneteenth. And in November, top pages were overwhelmingly related to the winners and the losers of the US election.</p>
+		<p>We’ve pulled together the most-read English-language Wikipedia page for every day of 2020 excluding the Main Page and the Search page. While they tend to highlight the events, concerns, and people of the year, there are a few unexpected twists, like Johnny Bravo goes to Bollywood.</p>
+	</>
+);
+
+<Canvas>
+	<Story
+		args={{
+			children: defaultChildren,
+			size: 'small',
+		}}
+		name="Small"
+	>
+		{args => <Constrain {...args} />}
+	</Story>
+</Canvas>
+
+<ArgsTable story="Default" />
+
+## Stories
+
+### Medium
+
+<Canvas>
+	<Story
+		args={{
+			children: defaultChildren,
+			size: 'medium',
+		}}
+		name="Medium"
+	>
+		{args => <Constrain {...args} />}
+	</Story>
+</Canvas>
+
+### Large
+
+<Canvas>
+	<Story
+		args={{
+			children: defaultChildren,
+			size: 'large',
+		}}
+		name="Large"
+	>
+		{args => <Constrain {...args} />}
+	</Story>
+</Canvas>
+
+### Extra Large
+
+<Canvas>
+	<Story
+		args={{
+			children: defaultChildren,
+			size: 'extra-large',
+		}}
+		name="Extra Large"
+	>
+		{args => <Constrain {...args} />}
+	</Story>
+</Canvas>

--- a/src/components/Constrain/Constrain.tsx
+++ b/src/components/Constrain/Constrain.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import styles from './Constrain.scss';
+
+export default function Constrain ( props: {
+	/**
+	 * Children that will be constrained by the container.
+	 */
+	children: React.ReactNode,
+
+	/**
+	 * The size of the constrained container.
+	 */
+	size: 'small' | 'medium' | 'large' | 'extra-large',
+} ) {
+	return (
+		<div className={`${styles.container} ${styles[ props.size ]}`}>
+			{props.children}
+		</div>
+	);
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -6,6 +6,7 @@ export { default as Blockquote } from './Blockquote/Blockquote';
 export { default as CalloutCard } from './CalloutCard/CalloutCard';
 export { default as Checkbox } from './Checkbox/Checkbox';
 export { default as ColorScheme, schemes } from './ColorScheme/ColorScheme';
+export { default as Constrain } from './Constrain/Constrain';
 export { default as EmojiList } from './EmojiList/EmojiList';
 export { default as FormLabel } from './FormLabel/FormLabel';
 export { default as Hed } from './Hed/Hed';


### PR DESCRIPTION
This replaces the `constrain` mixin with a layout component. Usage:

```
<Constrain size="small">
  <MyStuff />
</Constrain>
```

I am shooting for a one-div solution, this is the simplest I could come up with. One disadvantage of this approach is that the gutters will not collapse against any adjacent (horizontally aligned) siblings (since they are achieved with `padding`). I looked and couldn't find any place where we relied on collapsing gutters, but correct me if I'm wrong. Horizontal collapsing margins is not something we often think about at all, really.

Collapsing gutters are achievable but would probably require an additional "inner" div.

There is also a one-div CSS grid solution I thought of, if you're curious:

```scss
.container {
  display: grid;
  grid-template-columns: minmax($gutter-width, auto) minmax(auto, $max-width) minmax($gutter-width, auto);

  &::before,
  &::after {
    display: block;
    content: '';
  }
}
```

Thoughts?