### PR TITLE
Hotfix for type=search textarea border radius style

### DIFF
--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -17,7 +17,8 @@
 
 	// our resets specify &[type=search] with a border-radius of 0 to override iOS
 	// styles, so we must also use that specificity here or the reset will take precedence
-	&, &[type=search] {
+	&,
+	&[type=search] {
 		border-radius: tokens.$size-border-radius;
 	}
 

--- a/src/components/TextInput/TextInput.scss
+++ b/src/components/TextInput/TextInput.scss
@@ -10,11 +10,16 @@
 
 	background-color: color-scheme.$background-2;
 	border: borders.$solid-interactive;
-	border-radius: tokens.$size-border-radius;
 	color: inherit;
 	font-size: 16px;
 	transition: border-color, 0.25s;
 	width: 100%;
+
+	// our resets specify &[type=search] with a border-radius of 0 to override iOS
+	// styles, so we must also use that specificity here or the reset will take precedence
+	&, &[type=search] {
+		border-radius: tokens.$size-border-radius;
+	}
 
 	&::placeholder {
 		color: color-scheme.$typography-faint;


### PR DESCRIPTION
Due to [a rule in our style resets](https://github.com/Quartz/styles/blob/main/scss/helpers/resets.scss#L73), `TextInput` with a type of `search` always has square corners, which doesn't match our style elsewhere.

<img width="478" alt="Screen Shot 2021-04-13 at 9 25 24 AM" src="https://user-images.githubusercontent.com/784999/114559936-379cef00-9c3a-11eb-8887-bed208ad0fe4.png">
