### PR TITLE
Fix typo in Icon / svgs

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -95,7 +95,7 @@ export default function Icon ( props: {
 		fill,
 		height: size,
 		version: '1.1',
-		xmnls: 'http://www.w3.org/2000/svg',
+		xmlns: 'http://www.w3.org/2000/svg',
 	};
 
 	const Icon = svgIcons[props.name];


### PR DESCRIPTION
Typo in the Icon component means our AMP pages aren't being indexed - oops.

<img width="798" alt="Screen Shot 2021-04-22 at 9 55 56 AM" src="https://user-images.githubusercontent.com/29870016/115726754-02d31b00-a351-11eb-8976-9444236c778e.png">
