### PR TITLE
QZ-946 make @quartz/styles a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2396,9 +2396,8 @@
 			}
 		},
 		"@quartz/styles": {
-			"version": "github:Quartz/styles#020534760fb3ab068837cd501539775c65750148",
-			"from": "github:Quartz/styles#0.2.1",
-			"dev": true,
+			"version": "github:Quartz/styles#9248587b32a91cb6d6e466717cc963198e2c1cb0",
+			"from": "github:Quartz/styles#0.2.2",
 			"requires": {
 				"normalize.css": "^8.0.1"
 			}
@@ -13999,8 +13998,7 @@
 		"normalize.css": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
-			"integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
-			"dev": true
+			"integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
 		},
 		"npm-run-all": {
 			"version": "4.1.5",

--- a/package.json
+++ b/package.json
@@ -29,13 +29,14 @@
 	"main": "src/components/index",
 	"module": "src/components/index",
 	"types": "dist/index.d.ts",
-	"dependencies": {},
+	"dependencies": {
+		"@quartz/styles": "github:Quartz/styles#0.2.2"
+	},
 	"devDependencies": {
 		"@babel/core": "^7.12.9",
 		"@quartz/eslint-config-react": "^1.1.5",
 		"@quartz/js-utils": "^1.1.1",
 		"@quartz/stylelint-config": "^1.2.0",
-		"@quartz/styles": "github:Quartz/styles#0.2.1",
 		"@storybook/addon-a11y": "^6.1.10",
 		"@storybook/addon-actions": "^6.1.10",
 		"@storybook/addon-essentials": "^6.1.10",


### PR DESCRIPTION
As part of https://github.com/Quartz/qz-react/pull/6454, this PR moves the `@quartz/styles` package into the dependencies so that `qz-react` can run `@quartz/interface` without errors.

When we move `@quartz/interface` into the `qz-react` repo, we won't need to import `@quartz/styles` any more.

